### PR TITLE
Point setup.py to the proper README file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name='djangosaml2-knaperek',
     version='0.14.0',
     description='pysaml2 integration for Django',
-    long_description='\n\n'.join([read('README'), read('CHANGES')]),
+    long_description='\n\n'.join([read('README.rst'), read('CHANGES')]),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",


### PR DESCRIPTION
This fixes issues with installing the library through pip (since `README` was renamed to `README.rst`)
