### PR TITLE
Custom relay state default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -320,6 +320,13 @@ can set in the settings.py file::
 
 This setting is True by default.
 
+  ACS_DEFAULT_REDIRECT_URL = reverse_lazy('some_url_name')
+
+This setting lets you specify a URL for redirection after a successful
+authentication. Particularly useful when you only plan to use
+IdP initiated login and the IdP does not have a configured RelayState
+parameter. The default is ``/``.
+
 The other thing you will probably want to configure is the mapping of
 SAML2 user attributes to Django user attributes. By default only the
 User.username attribute is mapped but you can add more attributes or

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -243,11 +243,12 @@ def assertion_consumer_service(request,
     post_authenticated.send_robust(sender=user, session_info=session_info)
 
     # redirect the user to the view where he came from
-    default_relay_state = get_custom_setting('ACS_DEFAULT_REDIRECT_URL', '/')
+    default_relay_state = get_custom_setting('ACS_DEFAULT_REDIRECT_URL',
+                                             settings.LOGIN_REDIRECT_URL)
     relay_state = request.POST.get('RelayState', default_relay_state)
     if not relay_state:
         logger.warning('The RelayState parameter exists but is empty')
-        relay_state = settings.LOGIN_REDIRECT_URL
+        relay_state = default_relay_state
     logger.debug('Redirecting to the RelayState: %s', relay_state)
     return HttpResponseRedirect(relay_state)
 

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -243,7 +243,8 @@ def assertion_consumer_service(request,
     post_authenticated.send_robust(sender=user, session_info=session_info)
 
     # redirect the user to the view where he came from
-    relay_state = request.POST.get('RelayState', '/')
+    default_relay_state = get_custom_setting('ACS_DEFAULT_REDIRECT_URL', '/')
+    relay_state = request.POST.get('RelayState', default_relay_state)
     if not relay_state:
         logger.warning('The RelayState parameter exists but is empty')
         relay_state = settings.LOGIN_REDIRECT_URL


### PR DESCRIPTION
This adds support for a custom setting to redirect ACS after a successful authentication when the IdP does not specify a RelayState attribute.
