### PR TITLE
Remove identity cache get & set

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -72,6 +72,7 @@ class Saml2Backend(ModelBackend):
             logger.error('Session info or attribute mapping are None')
             return None
 
+        logger.debug('session_info: {}'.format(session_info))
         if not 'ava' in session_info:
             logger.error('"ava" key not found in session_info')
             return None

--- a/djangosaml2/cache.py
+++ b/djangosaml2/cache.py
@@ -76,28 +76,6 @@ class IdentityCache(Cache):
         self._db = DjangoSessionCacheAdapter(django_session, '_identities')
         self._sync = True
 
-    def get(self, name_id, entity_id, *args, **kwargs):
-        info = super(IdentityCache, self).get(name_id, entity_id, *args, **kwargs)
-        try:
-            name_id = info['name_id']
-        except KeyError:
-            pass
-        else:
-            info = dict(info)
-            info['name_id'] = decode(name_id)
-
-        return info
-
-    def set(self, name_id, entity_id, info, *args, **kwargs):
-        try:
-            name_id = info['name_id']
-        except KeyError:
-            pass
-        else:
-            info = dict(info)
-            info['name_id'] = code(name_id)
-        return super(IdentityCache, self).set(name_id, entity_id, info, *args, **kwargs)
-
 
 class StateCache(DjangoSessionCacheAdapter):
     """Store state information that is needed to associate a logout


### PR DESCRIPTION
As discussed on #4, these are no longer necessary since pysaml2 takes care of this now. It might be prudent to check that they're taken care of by pysaml2 in case they're later removed, but for now, the custom behaviour isn't required.

Added some debug logging in a separate commit that you can take or leave as you see fit, but helped me to get set up.
