### PR TITLE
Reverting changes in 8c6047c9441b81157f6907f30a6aec88195e5320

### DIFF
--- a/djangosaml2/cache.py
+++ b/djangosaml2/cache.py
@@ -37,6 +37,9 @@ class DjangoSessionCacheAdapter(dict):
     def sync(self):
         # Changes in inner objects do not cause session invalidation
         # https://docs.djangoproject.com/en/1.9/topics/http/sessions/#when-sessions-are-saved
+        objs = {}
+        objs.update(self)
+        self._set_objects(objs)
         self.session.modified = True
 
 


### PR DESCRIPTION
The changes in 8c6047c9441b81157f6907f30a6aec88195e5320 broke SAML login under UWSGI. Specifically, the SAML session ID wasn't being saved, therefore a session cookie was not created. This prevented the verification of the SAMLResponse from succeeding.
