### PR TITLE
The fix to an error KeyError at /saml2/logout/

### DIFF
--- a/djangosaml2/cache.py
+++ b/djangosaml2/cache.py
@@ -37,6 +37,10 @@ class DjangoSessionCacheAdapter(dict):
     def sync(self):
         # Changes in inner objects do not cause session invalidation
         # https://docs.djangoproject.com/en/1.9/topics/http/sessions/#when-sessions-are-saved
+
+        #add objects to session
+        self._set_objects(self)
+        #invalidate session
         self.session.modified = True
 
 


### PR DESCRIPTION
The short fix to the djangosaml2 logout error:
`KeyError at /saml2/logout/` 
the error is described in [issue 10](https://github.com/knaperek/djangosaml2/issues/10)
