### PR TITLE
Add kwargs to backend's authenticate method so that multiple auth backends can be used at the same time

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -67,7 +67,7 @@ def get_saml_user_model():
 class Saml2Backend(ModelBackend):
 
     def authenticate(self, session_info=None, attribute_mapping=None,
-                     create_unknown_user=True):
+                     create_unknown_user=True, **kwargs):
         if session_info is None or attribute_mapping is None:
             logger.error('Session info or attribute mapping are None')
             return None


### PR DESCRIPTION
This way, when using multiple authentication backends (ie, a custom django auth backend and custom Saml2Backend) and the first custom backend does not authenticate the user, this other backend can process the next authentication request attempt without crashing.

For example: I have password auth backend and djangosaml2 backend for my site. A user wants to authenticate using password. Let's say the user cannot authenticate with password because of reasons (like... he is only allowed to log in through SSO and my custom auth backend checks for that).

When auth backends says no to password login, django tries djangosaml2 backend passing as kwargs the username and password. These are unexpected keyword arguments for djangosaml2 backend, but it should still be supported as **kwargs so that authentication does not blow up when using multiple backends.

If you look at the code for Auth.ModelBackend you will see that the authenticate method signature contains a **kwargs for this very reason.
