### PR TITLE
Exclude top-level tests package & subpackages from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url="https://github.com/knaperek/djangosaml2",
     download_url="https://pypi.python.org/pypi/djangosaml2",
     license='Apache 2.0',
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
Hi,

when package is installed tests are installed as a top-level tests package in site-packages. It's better to not to take such a generic package name in order to avoid conflicts.
