### PR TITLE
Remove bogus python-memecached requirement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'pysaml2==4.0.5',
-        'python-memcached==1.48',
+        'pysaml2==4.0.5'
         ],
     )


### PR DESCRIPTION
The code doesn't appear to ever use this and thus should not be an install requirement.
