### PR TITLE
Don't call tree.iter as it only exists in python 2.7, must use tree.g…

### DIFF
--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -52,7 +52,7 @@ def get_hidden_form_inputs(html):
     """ Extracts name/value pairs from hidden input tags in an html form."""
     pairs = dict()
     tree = ElementTree.fromstring(html)
-    for node in tree.iter():
+    for node in tree.getiterator():
         if node.tag == 'input':
             element = dict(node.items())
             if element['type'] == 'hidden':

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -52,7 +52,12 @@ def get_hidden_form_inputs(html):
     """ Extracts name/value pairs from hidden input tags in an html form."""
     pairs = dict()
     tree = ElementTree.fromstring(html)
-    for node in tree.getiterator():
+    # python 2.6 doesn't have iter
+    if hasattr(tree, 'iter'):
+        node_iter = tree.iter()
+    else:
+        node_iter = tree.getiterator()
+    for node in node_iter:
         if node.tag == 'input':
             element = dict(node.items())
             if element['type'] == 'hidden':


### PR DESCRIPTION
…etiterator

tree.getiterator seems to be the standard for ElementTree, where iter is for lxml compatibility. 

https://stackoverflow.com/questions/3077010/what-is-the-difference-between-getiterator-and-iter-wrt-to-lxml
