### PR TITLE
Use defusedxml instead of etree

### DIFF
--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from xml.etree import ElementTree
+from defusedxml import ElementTree
 from django.conf import settings
 
 
@@ -51,7 +51,7 @@ def get_location(http_info):
 def get_hidden_form_inputs(html):
     """ Extracts name/value pairs from hidden input tags in an html form."""
     pairs = dict()
-    tree = ElementTree.fromstring(html)
+    tree = ElementTree.fromstring(html, forbid_dtd=True)
     # python 2.6 doesn't have iter
     if hasattr(tree, 'iter'):
         node_iter = tree.iter()

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -19,6 +19,8 @@ try:
     from xml.etree import ElementTree
 except ImportError:
     from elementtree import ElementTree
+from defusedxml.common import (DTDForbidden, EntitiesForbidden,
+                               ExternalReferenceForbidden)
 
 from django.conf import settings
 from django.contrib import auth
@@ -175,6 +177,8 @@ def login(request,
                     'target_url': result['url'],
                     'params': params,
                     })
+        except (DTDForbidden, EntitiesForbidden, ExternalReferenceForbidden):
+            raise PermissionDenied
         except TemplateDoesNotExist:
             return HttpResponse(result['data'])
     else:

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'pysaml2==4.0.5'
+        'pysaml2==4.0.5',
+        'defusedxml==0.4.1'
         ],
     )


### PR DESCRIPTION
Use [`defusedxml`](https://pypi.python.org/pypi/defusedxml) instead of `etree`. This mitigates the possible
vulnerability to billion-laughs and quadratic blowup. The following
exceptions may be thrown when parsing bad xml.
- `EntitiesForbidden`: when parsing xml with a `ENTITY` declaration
- `DTDForbidden`: when parsing xml with a `DOCTYPE` processing instruction

AFAIK the xml we expect should not have a `DOCTYPE` processing instruction
or `ENTITY` declaration. As a result, there should be no side effects due
to this change under normal operation.
