### PR TITLE
Render error template on finish_logout error

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -39,6 +39,7 @@ from djangosaml2.conf import get_config
 from djangosaml2.tests import conf
 from djangosaml2.tests.auth_response import auth_response
 from djangosaml2.signals import post_authenticated
+from djangosaml2.views import finish_logout
 
 User = get_user_model()
 
@@ -419,6 +420,11 @@ class SAML2Tests(TestCase):
                 'SAMLRequest': deflate_and_base64_encode(saml_request),
                 })
         self.assertContains(response, 'Logout error', status_code=200)
+
+    def test_finish_logout_renders_error_template(self):
+        request = RequestFactory().get('/bar/foo')
+        response = finish_logout(request, None)
+        self.assertContains(response, "<h1>Logout error</h1>", status_code=200)
 
     def _test_metadata(self):
         settings.SAML_CONFIG = conf.create_conf(

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -403,7 +403,7 @@ def finish_logout(request, response, next_page=None):
         return django_logout(request, next_page=next_page)
     else:
         logger.error('Unknown error during the logout')
-        return HttpResponse('Error during logout')
+        return render(request, "djangosaml2/logout_error.html", {})
 
 
 def metadata(request, config_loader_path=None, valid_for=None):


### PR DESCRIPTION
Previously if finish_logout() could not complete the logout, a simple HttpResponse() was returned. Render instead the djangosaml2/logout_error.html template, so implementers can override it to provide a more useful error page to users.

Closes #32