### PR TITLE
restore #30 "if user attribute is callable then call it..."

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -233,8 +233,14 @@ class Saml2Backend(ModelBackend):
             try:
                 for attr in django_attrs:
                     if hasattr(user, attr):
-                        modified = self._set_attribute(
-                            user, attr, attributes[saml_attr][0])
+                        user_attr = getattr(user, attr)
+                        if callable(user_attr):
+                            modified = user_attr(
+                                    attributes[saml_attr])
+                        else:
+                            modified = self._set_attribute(
+                                    user, attr, attributes[saml_attr][0])
+
                         user_modified = user_modified or modified
 
                     elif profile is not None and hasattr(profile, attr):

--- a/tests/testprofiles/models.py
+++ b/tests/testprofiles/models.py
@@ -23,7 +23,12 @@ if django.VERSION < (1, 7):
         user = models.OneToOneField('auth.User')
         age = models.CharField(max_length=100, blank=True)
 
+        def process_first_name(self, first_name):
+            self.first_name = first_name[0]
 else:
     from django.contrib.auth.models import AbstractUser
     class TestUser(AbstractUser):
         age = models.CharField(max_length=100, blank=True)
+
+        def process_first_name(self, first_name):
+            self.first_name = first_name[0]

--- a/tests/testprofiles/tests.py
+++ b/tests/testprofiles/tests.py
@@ -68,3 +68,24 @@ class Saml2BackendTests(TestCase):
             self.assertEquals(user.get_profile().age, '22')
         else:
             self.assertEquals(user.age, '22')
+
+    def test_update_user_callable_attributes(self):
+        user = User.objects.create(username='john')
+
+        backend = Saml2Backend()
+        attribute_mapping = {
+            'uid': ('username', ),
+            'mail': ('email', ),
+            'cn': ('process_first_name', ),
+            'sn': ('last_name', ),
+            }
+        attributes = {
+            'uid': ('john', ),
+            'mail': ('john@example.com', ),
+            'cn': ('John', ),
+            'sn': ('Doe', ),
+            }
+        backend.update_user(user, attributes, attribute_mapping)
+        self.assertEquals(user.email, 'john@example.com')
+        self.assertEquals(user.first_name, 'John')
+        self.assertEquals(user.last_name, 'Doe')


### PR DESCRIPTION
The changes made in https://github.com/knaperek/djangosaml2/pull/30/files seem to have been overridden https://github.com/knaperek/djangosaml2/commit/73b6a4544cf8baf263490a19e6fd83aa480e9884#diff-2cd834de0333b1e660410e18cca31448L210 so the `process_groups` example no longer appears to work.

This restores the `callable` change