### PR TITLE
Don't parse html with xml parser

### DIFF
--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -46,21 +46,3 @@ def get_location(http_info):
     header_name, header_value = headers[0]
     assert header_name == 'Location'
     return header_value
-
-
-def get_hidden_form_inputs(html):
-    """ Extracts name/value pairs from hidden input tags in an html form."""
-    pairs = dict()
-    tree = ElementTree.fromstring(html.replace('&', '&amp;'), forbid_dtd=True)
-    # python 2.6 doesn't have iter
-    if hasattr(tree, 'iter'):
-        node_iter = tree.iter()
-    else:
-        node_iter = tree.getiterator()
-    for node in node_iter:
-        if node.tag == 'input':
-            element = dict(node.items())
-            if element['type'] == 'hidden':
-                pairs[element['name']] = element['value']
-    return pairs
-

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from defusedxml import ElementTree
 from django.conf import settings
 
 
 def get_custom_setting(name, default=None):
-    if hasattr(settings, name):
-        return getattr(settings, name)
-    else:
-        return default
+    return getattr(settings, name, default)
 
 
 def available_idps(config, langpref=None):

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -180,7 +180,7 @@ def login(request,
         else:
             # manually get request XML to build our own template
             request_id, request_xml = client.create_authn_request(
-                client._sso_location(selected_idp, binding),
+                client.sso_location(selected_idp, binding),
                 binding=binding)
             return render(request, post_binding_form_template, {
                 'target_url': result['url'],

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -156,7 +156,9 @@ def login(request,
     # http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf
     binding = BINDING_HTTP_POST if getattr(conf, '_sp_authn_requests_signed', False) else BINDING_HTTP_REDIRECT
 
+    client = Saml2Client(conf)
     http_response = None
+    
     logger.debug('Redirecting user to the IdP via %s binding.', binding)
     if binding == BINDING_HTTP_REDIRECT:
         try:


### PR DESCRIPTION
Previously, when using a custom template, we would parse the html given by pysaml2 with an xml parser to get the request xml.  This broke when the SSO url had an & in it though, which was fixed by https://github.com/knaperek/djangosaml2/pull/41   ... however, other characters can cause similar xml parsing errors.  The real issue is that we are using an xml parser for generated html, which could change to be invalid xml with any pysaml2 update.  

To avoid this, I've redone the logic so that in the case of a http-post binding with a custom template, instead of asking pysaml2 for the full html we only ask for the request xml and utilize.  This removes the need for any xml parsing there at all.   