### PR TITLE
[py3 compat] Correctly handle bytes

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -204,7 +204,7 @@ def login(request,
             http_response = render(request, post_binding_form_template, {
                 'target_url': location,
                 'params': {
-                    'SAMLRequest': base64.b64encode(request_xml),
+                    'SAMLRequest': base64.b64encode(binary_type(request_xml)),
                     'RelayState': came_from,
                     },
                 })


### PR DESCRIPTION
`b64encode` requires `bytes` instead of `str` on py3, this is just one that I stumbled upon, there may be more py3 incompatible statements