### PR TITLE
got rid of only non ascii char in the file -- Gutiérrez --> Gutierrez

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,7 +40,7 @@ Changes
 0.14.0 (2016-01-28)
 -------------------
 - Upgrade to pysaml2-4.0.2. Thanks to kviktor
-- Django 1.9 support. Thanks to Jordi Gutiérrez Hermoso
+- Django 1.9 support. Thanks to Jordi Gutierrez Hermoso
 
 0.13.2 (2015-06-24)
 -------------------


### PR DESCRIPTION
as this breaks
pip install djangosaml2
in Docker containers based on Ubuntu 16.04 --
for some reason the default system encoding there is not utf-8 but ascii.