### PR TITLE
pass request to auth.authenticate

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -68,7 +68,7 @@ def get_saml_user_model():
 
 class Saml2Backend(ModelBackend):
 
-    def authenticate(self, session_info=None, attribute_mapping=None,
+    def authenticate(self, request, session_info=None, attribute_mapping=None,
                      create_unknown_user=True, **kwargs):
         if session_info is None or attribute_mapping is None:
             logger.error('Session info or attribute mapping are None')

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -276,7 +276,8 @@ def assertion_consumer_service(request,
         create_unknown_user = create_unknown_user()
 
     logger.debug('Trying to authenticate the user')
-    user = auth.authenticate(session_info=session_info,
+    user = auth.authenticate(request=request,
+                             session_info=session_info,
                              attribute_mapping=attribute_mapping,
                              create_unknown_user=create_unknown_user)
     if user is None:


### PR DESCRIPTION
In Django 1.11, the `auth.authenticate` call takes a `request` argument, and custom authentication backends are expected to take a positional `request` argument.

This was really handy for me since I had fork `Saml2Backend` to perform additional logic based on the specific request.

https://docs.djangoproject.com/en/1.11/topics/auth/default/#how-to-log-a-user-in
https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#writing-an-authentication-backend