### PR TITLE
Adding support for SHA256 signing

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -170,8 +170,8 @@ def login(request,
         try:
             # do not sign the xml itself, instead use the sigalg to
             # generate the signature as a URL param
-            sig_alg_option_map = {'sha1': SIG_RSA_SHA1',
-                                  'sha256': SIG_RSA_SHA256'}
+            sig_alg_option_map = {'sha1': SIG_RSA_SHA1,
+                                  'sha256': SIG_RSA_SHA256}
             sig_alg_option = getattr(conf, '_sp_authn_requests_signed_alg', 'sha1')
             sigalg = sig_alg_option_map[sig_alg_option] if sign_requests else None
             session_id, result = client.prepare_for_authenticate(

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -171,7 +171,7 @@ def login(request,
             # do not sign the xml itself, instead use the sigalg to
             # generate the signature as a URL param
             sig_alg = getattr(conf, '_sp_authn_requests_signed_alg', False)
-            sigalg = SIG_RSA_SHA1 if sign_requests and sig_alg == 'sha1' else None
+            sigalg = SIG_RSA_SHA1 if sign_requests and sig_alg == 'sha1' or sig_alg==False else None
             sigalg = SIG_RSA_SHA256 if sign_requests and sig_alg == 'sha256' else None
             session_id, result = client.prepare_for_authenticate(
                 entityid=selected_idp, relay_state=came_from,

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -170,9 +170,10 @@ def login(request,
         try:
             # do not sign the xml itself, instead use the sigalg to
             # generate the signature as a URL param
-            sig_alg = getattr(conf, '_sp_authn_requests_signed_alg', False)
-            sigalg = SIG_RSA_SHA1 if sign_requests and sig_alg == 'sha1' or sig_alg==False else None
-            sigalg = SIG_RSA_SHA256 if sign_requests and sig_alg == 'sha256' else None
+            sig_alg_option_map = {'sha1': SIG_RSA_SHA1',
+                                  'sha256': SIG_RSA_SHA256'}
+            sig_alg_option = getattr(conf, '_sp_authn_requests_signed_alg', 'sha1')
+            sigalg = sig_alg_option_map[sig_alg_option] if sign_requests else None
             session_id, result = client.prepare_for_authenticate(
                 entityid=selected_idp, relay_state=came_from,
                 binding=binding, sign=False, sigalg=sigalg)


### PR DESCRIPTION
This adds support for SHA256 signing, with a setting in the djangosaml2 config.
