### PR TITLE
Don't trim attribute values when field.max_length is None

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -272,7 +272,7 @@ class Saml2Backend(ModelBackend):
         Return True if the attribute was changed and False otherwise.
         """
         field = obj._meta.get_field(attr)
-        if len(value) > field.max_length:
+        if field.max_length is not None and len(value) > field.max_length:
             cleaned_value = value[:field.max_length]
             logger.warn('The attribute "%s" was trimmed from "%s" to "%s"',
                         attr, value, cleaned_value)


### PR DESCRIPTION
### Issue
When mapping SAML2 attribute values to a Django user object, the backend compares the SAML2 value's length with the user object field's `max_length` to determine if trimming is required.

Some Django field types do not set a numeric `max_length` attribute, such as `IntegerField` and `PositiveIntegerField`. The `max_length` attribute of these classes is `None` (inherited from their parent class, `Field`).

In the trace below, `max_length` is `None` (the field is a `PositiveIntegerField`) so we get `TypeError: unorderable types: int() > NoneType()` when comparing `len(value) > field.max_length`

### Solution
Check that `field.max_length is not None` before comparing `len(value) > field.max_length`

### Links to Django 1.11.3 Field source for reference:
[django/db/models/fields/__init__.py#L146](https://github.com/django/django/blob/1.11.3/django/db/models/fields/__init__.py#L146) (setting `self.max_length=None` by default)
[django/db/models/fields/__init__.py#L1804](https://github.com/django/django/blob/1.11.3/django/db/models/fields/__init__.py#L1804) (`IntegerField` does not override self.max_length)

### Environment
djangosaml 0.16.1
Django 1.11.3
Python 3.5.2
Ubuntu 16.04.2 LTS


### Full trace
```
ERROR 2017-07-22 00:50:29,546 exception 26875 140000857417472 Internal Server Error: /saml2/acs/
Traceback (most recent call last):
  File "/opt/app/venvs/current/lib/python3.5/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/django/views/decorators/http.py", line 40, in inner
    return func(request, *args, **kwargs)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/djangosaml2/views.py", line 282, in assertion_consumer_service
    create_unknown_user=create_unknown_user)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/django/contrib/auth/__init__.py", line 70, in authenticate
    user = _authenticate_with_backend(backend, backend_path, request, credentials)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/django/contrib/auth/__init__.py", line 115, in _authenticate_with_backend
    return backend.authenticate(*args, **credentials)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/djangosaml2/backends.py", line 115, in authenticate
    create_unknown_user, main_attribute, attributes, attribute_mapping)
  File "/opt/app/repo/project/config/saml/backends.py", line 22, in get_saml2_user
    user = super(SamlBackendWithGroups, self).get_saml2_user(create, main_attribute, attributes, attribute_mapping)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/djangosaml2/backends.py", line 152, in get_saml2_user
    return self._get_or_create_saml2_user(main_attribute, attributes, attribute_mapping)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/djangosaml2/backends.py", line 178, in _get_or_create_saml2_user
    user = self.update_user(user, attributes, attribute_mapping)
  File "/opt/app/venvs/current/lib/python3.5/site-packages/djangosaml2/backends.py", line 243, in update_user
    modified = self._set_attribute(user, attr, attr_value_list[0])
  File "/opt/app/venvs/current/lib/python3.5/site-packages/djangosaml2/backends.py", line 275, in _set_attribute
    if len(value) > field.max_length:
TypeError: unorderable types: int() > NoneType()
```

