### PR TITLE
Spelling fix

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -350,7 +350,7 @@ def logout(request, config_loader_path=None):
     subject_id = _get_subject_id(request.session)
     if subject_id is None:
         logger.warning(
-            'The session does not contains the subject id for user %s',
+            'The session does not contain the subject id for user %s',
             request.user)
 
     result = client.global_logout(subject_id)


### PR DESCRIPTION
"does not contains" contains an unnecessary 's'.