### PR TITLE
Expand error message

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -188,7 +188,7 @@ class Saml2Backend(ModelBackend):
             user = User.objects.get(**user_query_args)
             user = self.update_user(user, attributes, attribute_mapping)
         except User.DoesNotExist:
-            logger.error('The user "%s" does not exist', main_attribute)
+            logger.error('The user "%s" does not exist, searched %s', (main_attribute, django_user_main_attribute))
             return None
         except MultipleObjectsReturned:
             logger.error("There are more than one user with %s = %s",

--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -188,7 +188,7 @@ class Saml2Backend(ModelBackend):
             user = User.objects.get(**user_query_args)
             user = self.update_user(user, attributes, attribute_mapping)
         except User.DoesNotExist:
-            logger.error('The user "%s" does not exist, searched %s', (main_attribute, django_user_main_attribute))
+            logger.error('The user "%s" does not exist, searched %s', main_attribute, django_user_main_attribute)
             return None
         except MultipleObjectsReturned:
             logger.error("There are more than one user with %s = %s",


### PR DESCRIPTION
For several reasons I just triggered the following case:

SAML_USE_NAME_ID_AS_USERNAME = True
SAML_DJANGO_USER_MAIN_ATTRIBUTE = 'email'

I've been trying out different IdPs, which needed name as id and those which didn't.
Due to hard coding (sigh) djangosaml2idp returned a username instead of the email address I was configured for (not its fault), but then the logs report that a user that does exist can't be found since the search is looking for email addresses not usernames. 
I hope this change helps clarify the cause of the problem.