### PR TITLE
Test fails when LOGIN_REDIRECT_URL is not default

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -263,7 +263,7 @@ class SAML2Tests(TestCase):
 
         url = urlparse(location)
         # as the RelayState is empty we have redirect to LOGIN_REDIRECT_URL
-        self.assertEquals(url.path, '/accounts/profile/')
+        self.assertEquals(url.path, settings.LOGIN_REDIRECT_URL)
         self.assertEquals(force_text(new_user.id), self.client.session[SESSION_KEY])
 
     def test_missing_param_to_assertion_consumer_service_request(self):


### PR DESCRIPTION
When the LOGIN_REDIRECT_URL setting is set to something other than `/accounts/profile`, then this test fails when it should not.