### PR TITLE
Relax requirement for defusedxml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,6 @@ setup(
     zip_safe=False,
     install_requires=[
         'pysaml2==4.4.0',
-        'defusedxml==0.4.1'
+        'defusedxml>=0.4.1'
         ],
     )


### PR DESCRIPTION
It allows to install newer version of defusedxml library from EPEL repository: python2-defusedxml-0.5.0
