### PR TITLE
Inspect User model to determine Django user main attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -315,14 +315,15 @@ authentication. This assertion contains attributes about the user that
 was authenticated. It depends on the IdP configuration what exact
 attributes are sent to each SP it can talk to.
 
-When such assertion is received on the Django side it is used to find
-a Django user and create a session for it. By default djangosaml2 will
-do a query on the User model with the 'username' attribute but you can
-change it to any other attribute of the User model. For example,
-you can do this lookup using the 'email' attribute. In order to do so
-you should set the following setting::
+When such assertion is received on the Django side it is used to find a Django
+user and create a session for it. By default djangosaml2 will do a query on the
+User model with the USERNAME_FIELD_ attribute but you can change it to any
+other attribute of the User model. For example, you can do this lookup using
+the 'email' attribute. In order to do so you should set the following setting::
 
   SAML_DJANGO_USER_MAIN_ATTRIBUTE = 'email'
+
+.. _USERNAME_FIELD: https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD
 
 Please, use an unique attribute when setting this option. Otherwise
 the authentication process may fail because djangosaml2 will not know

--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -136,7 +136,9 @@ class Saml2Backend(ModelBackend):
 
     def get_django_user_main_attribute(self):
         return getattr(
-            settings, 'SAML_DJANGO_USER_MAIN_ATTRIBUTE', 'username')
+            settings,
+            'SAML_DJANGO_USER_MAIN_ATTRIBUTE',
+            getattr(get_saml_user_model(), 'USERNAME_FIELD', 'username'))
 
     def get_django_user_main_attribute_lookup(self):
         return getattr(settings, 'SAML_DJANGO_USER_MAIN_ATTRIBUTE_LOOKUP', '')

--- a/djangosaml2/settings.py
+++ b/djangosaml2/settings.py
@@ -1,6 +1,0 @@
-from django.conf import settings
-
-SAML_DJANGO_USER_MAIN_ATTRIBUTE = getattr(
-    settings, 'SAML_DJANGO_USER_MAIN_ATTRIBUTE', 'username')
-SAML_DJANGO_USER_MAIN_ATTRIBUTE_LOOKUP = getattr(
-    settings, 'SAML_DJANGO_USER_MAIN_ATTRIBUTE_LOOKUP', '')

--- a/tests/testprofiles/models.py
+++ b/tests/testprofiles/models.py
@@ -15,8 +15,6 @@
 
 import django
 from django.db import models
-from django.contrib.auth.models import User
-from django.conf import settings
 
 if django.VERSION < (1, 7):
     class TestProfile(models.Model):
@@ -32,3 +30,10 @@ else:
 
         def process_first_name(self, first_name):
             self.first_name = first_name[0]
+
+    class StandaloneUserModel(models.Model):
+        """
+        Does not inherit from Django's base abstract user and does not define a
+        USERNAME_FIELD.
+        """
+        username = models.CharField(max_length=30, unique=True)

--- a/tests/testprofiles/models.py
+++ b/tests/testprofiles/models.py
@@ -27,7 +27,6 @@ else:
     from django.contrib.auth.models import AbstractUser
     class TestUser(AbstractUser):
         age = models.CharField(max_length=100, blank=True)
-
         def process_first_name(self, first_name):
             self.first_name = first_name[0]
 

--- a/tests/testprofiles/tests.py
+++ b/tests/testprofiles/tests.py
@@ -117,6 +117,11 @@ class Saml2BackendTests(TestCase):
     def test_django_user_main_attribute(self):
         backend = Saml2Backend()
 
+        old_username_field = User.USERNAME_FIELD
+        User.USERNAME_FIELD = 'slug'
+        self.assertEquals(backend.get_django_user_main_attribute(), 'slug')
+        User.USERNAME_FIELD = old_username_field
+
         with override_settings(AUTH_USER_MODEL='auth.User'):
             self.assertEquals(
                 DjangoUserModel.USERNAME_FIELD,


### PR DESCRIPTION
Instead of defaulting `SAML_DJANGO_USER_MAIN_ATTRIBUTE` to `'username'`, inspect the current user model and use [`USERNAME_FIELD`](https://docs.djangoproject.com/en/dev/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD). This value should be provided for any custom `User` model inheriting from `AbstractBaseUser`.