### PR TITLE
Expect a 403 status code in test_incomplete_logout

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -431,7 +431,7 @@ class SAML2Tests(TestCase):
         response = self.client.get(reverse('saml2_ls'), {
                 'SAMLRequest': deflate_and_base64_encode(saml_request),
                 })
-        self.assertContains(response, 'Logout error', status_code=200)
+        self.assertContains(response, 'Logout error', status_code=403)
 
     def test_finish_logout_renders_error_template(self):
         request = RequestFactory().get('/bar/foo')


### PR DESCRIPTION
de34c002a315d42e882069726fc2f27a8fbbbffa changed the status code of the logout error page to be 403 instead of 200, but this test was not updated.