### PR TITLE
Fix undefined variable in tests

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -363,7 +363,7 @@ class SAML2Tests(TestCase):
                                       expected_request)
 
         # now simulate a logout response sent by the idp
-        request_id = re.findall(r' ID="(.*?)" ', xml)[0]
+        request_id = re.findall(r' ID="(.*?)" ', expected_request)[0]
         instant = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
 
         saml_response = """<?xml version='1.0' encoding='UTF-8'?>


### PR DESCRIPTION
Even though that test is skipped, it's probably better to keep it running.