### PR TITLE
 Add compatibility with Django master

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -24,11 +24,17 @@ from django.conf import settings
 from django.contrib.auth import SESSION_KEY, get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.template import Template, Context
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.utils.text import force_text
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.text import force_text
 from django.utils.six.moves.urllib.parse import urlparse, parse_qs
 
 from saml2.config import SPConfig

--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -22,14 +22,13 @@ import sys
 
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY, get_user_model
-from django.contrib.auth.models import User, AnonymousUser
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.urlresolvers import reverse
 from django.template import Template, Context
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.utils.text import force_text
-from django.utils.six import text_type
 from django.utils.six.moves.urllib.parse import urlparse, parse_qs
 
 from saml2.config import SPConfig

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.http import is_safe_url
 from django.utils.module_loading import import_string
 from saml2.s_utils import UnknownSystemEntity
 
@@ -78,3 +80,11 @@ def fail_acs_response(request, *args, **kwargs):
     failure_function = import_string(get_custom_setting('SAML_ACS_FAILURE_RESPONSE_FUNCTION',
                                                         'djangosaml2.acs_failures.template_failure'))
     return failure_function(request, *args, **kwargs)
+
+
+def is_safe_url_compat(url, allowed_hosts=None, require_https=False):
+    if django.VERSION >= (1, 11):
+        return is_safe_url(url, allowed_hosts=allowed_hosts, require_https=require_https)
+    assert len(allowed_hosts) == 1
+    host = allowed_hosts.pop()
+    return is_safe_url(url, host=host)

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -24,7 +24,11 @@ except ImportError:
 from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.views import logout as django_logout
+try:
+    from django.contrib.auth.views import LogoutView
+    django_logout = LogoutView.as_view()
+except ImportError:
+    from django.contrib.auth.views import logout as django_logout
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import Http404, HttpResponse
 from django.http import HttpResponseRedirect  # 30x
@@ -33,7 +37,6 @@ from django.http import HttpResponseServerError  # 50x
 from django.views.decorators.http import require_POST
 from django.shortcuts import render
 from django.template import TemplateDoesNotExist
-from django.utils.http import is_safe_url
 from django.utils.six import text_type, binary_type
 from django.views.decorators.csrf import csrf_exempt
 
@@ -51,7 +54,10 @@ from djangosaml2.cache import StateCache
 from djangosaml2.conf import get_config
 from djangosaml2.overrides import Saml2Client
 from djangosaml2.signals import post_authenticated
-from djangosaml2.utils import fail_acs_response, get_custom_setting, available_idps, get_location, get_idp_sso_supported_bindings
+from djangosaml2.utils import (
+    available_idps, fail_acs_response, get_custom_setting,
+    get_idp_sso_supported_bindings, get_location, is_safe_url_compat,
+)
 
 
 logger = logging.getLogger('djangosaml2')
@@ -106,7 +112,7 @@ def login(request,
         came_from = settings.LOGIN_REDIRECT_URL
 
     # Ensure the user-originating redirection url is safe.
-    if not is_safe_url(url=came_from, host=request.get_host()):
+    if not is_safe_url_compat(url=came_from, allowed_hosts={request.get_host()}):
         came_from = settings.LOGIN_REDIRECT_URL
 
     # if the user is already authenticated that maybe because of two reasons:
@@ -315,7 +321,7 @@ def assertion_consumer_service(request,
     if not relay_state:
         logger.warning('The RelayState parameter exists but is empty')
         relay_state = default_relay_state
-    if not is_safe_url(url=relay_state, host=request.get_host()):
+    if not is_safe_url_compat(url=relay_state, allowed_hosts={request.get_host()}):
         relay_state = settings.LOGIN_REDIRECT_URL
     logger.debug('Redirecting to the RelayState: %s', relay_state)
     return HttpResponseRedirect(relay_state)
@@ -451,7 +457,7 @@ def finish_logout(request, response, next_page=None):
     if response and response.status_ok():
         if next_page is None and hasattr(settings, 'LOGOUT_REDIRECT_URL'):
             next_page = settings.LOGOUT_REDIRECT_URL
-        logger.debug('Performing django_logout with a next_page of %s',
+        logger.debug('Performing django logout with a next_page of %s',
                      next_page)
         return django_logout(request, next_page=next_page)
     else:

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -28,7 +28,7 @@ from django.contrib.auth.views import logout as django_logout
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import Http404, HttpResponse
 from django.http import HttpResponseRedirect  # 30x
-from django.http import  HttpResponseBadRequest, HttpResponseForbidden  # 40x
+from django.http import HttpResponseBadRequest  # 40x
 from django.http import HttpResponseServerError  # 50x
 from django.views.decorators.http import require_POST
 from django.shortcuts import render

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 
+import django
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -34,7 +36,7 @@ INSTALLED_APPS = (
     'testprofiles',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -43,6 +45,9 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+if django.VERSION < (1, 10):
+    MIDDLEWARE_CLASSES = MIDDLEWARE
 
 ROOT_URLCONF = 'testprofiles.urls'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django{18,19,110,111,master}
+envlist = py27-django{18,19,110,111}, py36-django{18,19,110,111,master}
 
 [testenv]
 commands =


### PR DESCRIPTION
The only test that keep failing is:
```python
ERROR: test_logout_service_global (djangosaml2.tests.SAML2Tests)                                                                                                       [5/876]
----------------------------------------------------------------------                                                                                                        
Traceback (most recent call last):                                                                                                                                            
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/djangosaml2/tests/__init__.py", line 400, in test_logout_service_global             
    'SAMLRequest': deflate_and_base64_encode(saml_request),                                                                                                                   
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/django/test/client.py", line 517, in get                                            
    response = super().get(path, data=data, secure=secure, **extra)                    
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/django/test/client.py", line 332, in get                                            
    return self.generic('GET', path, secure=secure, **r)                               
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/django/test/client.py", line 404, in generic                                        
    return self.request(**r)               
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/django/test/client.py", line 485, in request                                        
    raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])                         
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/django/core/handlers/exception.py", line 35, in inner                               
    response = get_response(request)       
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/django/core/handlers/base.py", line 128, in _get_response                           
    response = self.process_exception_by_middleware(e, request)                        
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/django/core/handlers/base.py", line 126, in _get_response                           
    response = wrapped_callback(request, *callback_args, **callback_kwargs)            
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/djangosaml2/views.py", line 401, in logout_service                                  
    return do_logout_service(request, request.GET, BINDING_HTTP_REDIRECT, *args, **kwargs)                                                                                    
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/djangosaml2/views.py", line 447, in do_logout_service                               
    relay_state=data.get('RelayState', ''))
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/saml2/client.py", line 509, in handle_logout_request                                
    "single_logout_service", binding)      
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/saml2/entity.py", line 845, in _parse_request                                       
    xmlstr = self.unravel(enc_request, binding, request_cls.msgtype)                   
  File "/home/freitafr/dev/djangosaml2/.tox/py36-djangomaster/lib/python3.6/site-packages/saml2/entity.py", line 400, in unravel                                              
    raise UnravelError("Unravelling binding '%s' failed" % binding)                    
saml2.s_utils.UnravelError: Unravelling binding 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect' failed 
```

The reason for that failure is [Django ticket 28679](https://code.djangoproject.com/ticket/28679), a PR is in progress.

I updated tox matrix to run only Python 3.x against Django master, as Django 2.0 dropped Python 2.x compatibility.