### PR TITLE
Support several required fields during User creation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,10 @@ Thanks to plumdog
 
 Thanks to plumdog
 
+UNRELEASED
+----------
+- Allowed creating Users with multiple required fields.
+
 0.17.1 (2018-07-16)
 ----------
 - A 403 (permission denied) is now raised if a SAMLResponse is replayed, instead of 500.

--- a/tests/testprofiles/models.py
+++ b/tests/testprofiles/models.py
@@ -30,3 +30,13 @@ class StandaloneUserModel(models.Model):
     USERNAME_FIELD.
     """
     username = models.CharField(max_length=30, unique=True)
+
+
+class RequiredFieldUser(models.Model):
+    email = models.EmailField(unique=True)
+    email_verified = models.BooleanField()
+
+    USERNAME_FIELD = 'email'
+
+    def set_unusable_password(self):
+        pass

--- a/tests/testprofiles/tests.py
+++ b/tests/testprofiles/tests.py
@@ -134,6 +134,26 @@ class Saml2BackendTests(TestCase):
             logs.output,
         )
 
+    @override_settings(AUTH_USER_MODEL='testprofiles.RequiredFieldUser')
+    def test_create_user_with_required_fields(self):
+        backend = Saml2Backend()
+        attribute_mapping = {
+            'mail': ['email'],
+            'mail_verified': ['email_verified']
+        }
+        attributes = {
+            'mail': ['john@example.org'],
+            'mail_verified': [True],
+        }
+        # User creation does not fail if several fields are required.
+        user = backend._get_or_create_saml2_user(
+            'john@example.org',
+            attributes,
+            attribute_mapping,
+        )
+        self.assertEquals(user.email, 'john@example.org')
+        self.assertIs(user.email_verified, True)
+
     def test_django_user_main_attribute(self):
         backend = Saml2Backend()
 


### PR DESCRIPTION
Custom User models may have several required attributes, for example a
username and an email. If create is called directly based on
DJANGO_USER_MAIN_ATTRIBUTE, the NOT NULL constraint will be violated,
preventing to save that user. Instead, rely on update_user to call
save when most attributes have been defined on the user.

A nice side effect is that a database query might be saved, because the
INSERT query for new users could contain all attributes when save() is
called from update_user, while a first query (INSERT) was issued to
create the user, then update user would call save(), issuing an UPDATE
query.