### PR TITLE
Replace deprecated assert_ with more specific assertIn

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -143,8 +143,8 @@ class SAML2Tests(TestCase):
         self.assertEqual(url.path, '/simplesaml/saml2/idp/SSOService.php')
 
         params = parse_qs(url.query)
-        self.assert_('SAMLRequest' in params)
-        self.assert_('RelayState' in params)
+        self.assertIn('SAMLRequest', params)
+        self.assertIn('RelayState', params)
 
         saml_request = params['SAMLRequest'][0]
         if PY_VERSION < (2, 7):
@@ -172,8 +172,8 @@ class SAML2Tests(TestCase):
         self.assertEqual(url.path, '/simplesaml/saml2/idp/SSOService.php')
 
         params = parse_qs(url.query)
-        self.assert_('SAMLRequest' in params)
-        self.assert_('RelayState' in params)
+        self.assertIn('SAMLRequest', params)
+        self.assertIn('RelayState', params)
         self.assertEqual(params['RelayState'][0], next)
 
     def test_login_several_idps(self):
@@ -204,8 +204,8 @@ class SAML2Tests(TestCase):
         self.assertEqual(url.path, '/simplesaml/saml2/idp/SSOService.php')
 
         params = parse_qs(url.query)
-        self.assert_('SAMLRequest' in params)
-        self.assert_('RelayState' in params)
+        self.assertIn('SAMLRequest', params)
+        self.assertIn('RelayState', params)
 
         saml_request = params['SAMLRequest'][0]
         if PY_VERSION < (2, 7):
@@ -319,7 +319,7 @@ class SAML2Tests(TestCase):
                          '/simplesaml/saml2/idp/SingleLogoutService.php')
 
         params = parse_qs(url.query)
-        self.assert_('SAMLRequest' in params)
+        self.assertIn('SAMLRequest', params)
 
         saml_request = params['SAMLRequest'][0]
         if PY_VERSION < (2, 7):
@@ -353,7 +353,7 @@ class SAML2Tests(TestCase):
                          '/simplesaml/saml2/idp/SingleLogoutService.php')
 
         params = parse_qs(url.query)
-        self.assert_('SAMLRequest' in params)
+        self.assertIn('SAMLRequest', params)
 
         saml_request = params['SAMLRequest'][0]
         if PY_VERSION < (2, 7):
@@ -408,7 +408,7 @@ class SAML2Tests(TestCase):
                          '/simplesaml/saml2/idp/SingleLogoutService.php')
 
         params = parse_qs(url.query)
-        self.assert_('SAMLResponse' in params)
+        self.assertIn('SAMLResponse', params)
 
         saml_response = params['SAMLResponse'][0]
         if PY_VERSION < (2, 7):


### PR DESCRIPTION
More specific assert methods often provide better error messages in case of failure.

For a list of deprecated unittest methods, see:

https://docs.python.org/3/library/unittest.html#deprecated-aliases