### PR TITLE
Add universal wheel support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
As djangosaml2 is a pure Python library, it can be packaged as a universal wheel.

Advantages of wheels

* Faster installation.
* Avoids arbitrary code execution for installation. (Avoids `setup.py`)
* Allows better caching for testing and continuous integration.
* Creates `.pyc` files as part of installation to ensure they match the python interpreter used.
* More consistent installs across platforms and machines.

When you'd normally run `python setup.py sdist upload`, run instead `python setup.py sdist bdist_wheel upload`.

For more information on wheels, see:

http://pythonwheels.com/