### PR TITLE
[Waiting #109] Don't pass sigalg parameter when not signing login request

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -17,6 +17,12 @@
 import base64
 import datetime
 import re
+try:
+    # Prefer PyPI mock over unittest.mock to benefit from backported mock
+    # features (such as assert_called_once). Valid until Python 3.6.
+    import mock
+except ImportError:
+    from unittest import mock
 from unittest import skip
 
 from django.conf import settings
@@ -503,6 +509,43 @@ ID4zT0FcZASGuthM56rRJJSx
         ])
 
         self.assertEqual(rendered, expected)
+
+    def test_sigalg_not_passed_when_not_signing_request(self):
+        # monkey patch SAML configuration
+        settings.SAML_CONFIG = conf.create_conf(
+            sp_host='sp.example.com',
+            idp_hosts=['idp.example.com'],
+            metadata_file='remote_metadata_one_idp.xml',
+        )
+
+        with mock.patch(
+            'djangosaml2.views.Saml2Client.prepare_for_authenticate',
+            return_value=('session_id', {'url': 'fake'}),
+
+        ) as prepare_for_auth_mock:
+            self.client.get(reverse('saml2_login'))
+        prepare_for_auth_mock.assert_called_once()
+        _args, kwargs = prepare_for_auth_mock.call_args
+        self.assertNotIn('sigalg', kwargs)
+
+    def test_sigalg_passed_when_signing_request(self):
+        # monkey patch SAML configuration
+        settings.SAML_CONFIG = conf.create_conf(
+            sp_host='sp.example.com',
+            idp_hosts=['idp.example.com'],
+            metadata_file='remote_metadata_one_idp.xml',
+        )
+
+        settings.SAML_CONFIG['service']['sp']['authn_requests_signed'] = True
+        with mock.patch(
+            'djangosaml2.views.Saml2Client.prepare_for_authenticate',
+            return_value=('session_id', {'url': 'fake'}),
+
+        ) as prepare_for_auth_mock:
+            self.client.get(reverse('saml2_login'))
+        prepare_for_auth_mock.assert_called_once()
+        _args, kwargs = prepare_for_auth_mock.call_args
+        self.assertIn('sigalg', kwargs)
 
 
 def test_config_loader(request):

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -177,17 +177,18 @@ def login(request,
     logger.debug('Redirecting user to the IdP via %s binding.', binding)
     if binding == BINDING_HTTP_REDIRECT:
         try:
-            # do not sign the xml itself, instead use the sigalg to
-            # generate the signature as a URL param
-            sig_alg_option_map = {'sha1': SIG_RSA_SHA1,
-                                  'sha256': SIG_RSA_SHA256}
-            sig_alg_option = getattr(conf, '_sp_authn_requests_signed_alg', 'sha1')
-            sigalg = sig_alg_option_map[sig_alg_option] if sign_requests else None
             nsprefix = get_namespace_prefixes()
+            if sign_requests:
+                # do not sign the xml itself, instead use the sigalg to
+                # generate the signature as a URL param
+                sig_alg_option_map = {'sha1': SIG_RSA_SHA1,
+                                      'sha256': SIG_RSA_SHA256}
+                sig_alg_option = getattr(conf, '_sp_authn_requests_signed_alg', 'sha1')
+                kwargs["sigalg"] = sig_alg_option_map[sig_alg_option]
             session_id, result = client.prepare_for_authenticate(
                 entityid=selected_idp, relay_state=came_from,
-                binding=binding, sign=False, sigalg=sigalg,
-                nsprefix=nsprefix, **kwargs)
+                binding=binding, sign=False, nsprefix=nsprefix,
+                **kwargs)
         except TypeError as e:
             logger.error('Unable to know which IdP to use')
             return HttpResponse(str(e))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 
 import codecs
 import os
-import sys
 from setuptools import setup, find_packages
 
 
@@ -63,4 +62,8 @@ setup(
         'Django>=2.2',
         'pysaml2>=4.6.0',
         ],
+    tests_require=[
+        # Provides assert_called_once.
+        'mock;python_version < "3.6"',
+    ]
     )


### PR DESCRIPTION
PySAML2 expects a crypto backend to be configured if ``sigalg`` is passed.
This behaviour has been fixed in https://github.com/rohe/pysaml2/commit/4012711f8d510b62caa94392b91886f9c1423a6d, but the fix will not be available until the next release.