### PR TITLE
[Waiting #109] Make replay attacks result in 403

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Changes
 
 UNRELEASED
 ----------
+- A 403 (permission denied) is now raised if a SAMLResponse is replayed, instead of 500.
 - Log when fields are missing in a SAML response.
 - Log when attribute_mapping maps to nonexistent User fields.
 - Dropped compatibility for Python < 2.7 and Django < 1.8.

--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -257,6 +257,37 @@ class SAML2Tests(TestCase):
         self.assertEqual(url.path, settings.LOGIN_REDIRECT_URL)
         self.assertEqual(force_text(new_user.id), self.client.session[SESSION_KEY])
 
+    def test_assertion_consumer_service_no_session(self):
+        settings.SAML_CONFIG = conf.create_conf(
+            sp_host='sp.example.com',
+            idp_hosts=['idp.example.com'],
+            metadata_file='remote_metadata_one_idp.xml',
+        )
+
+        # session_id should start with a letter since it is a NCName
+        session_id = "a0123456789abcdef0123456789abcdef"
+        came_from = '/another-view/'
+        self.add_outstanding_query(session_id, came_from)
+
+        # Authentication is confirmed.
+        saml_response = auth_response(session_id, 'student')
+        response = self.client.post(reverse('saml2_acs'), {
+            'SAMLResponse': self.b64_for_post(saml_response),
+            'RelayState': came_from,
+        })
+        self.assertEqual(response.status_code, 302)
+        location = response['Location']
+        url = urlparse(location)
+        self.assertEqual(url.path, came_from)
+
+        # Session should no longer be in outstanding queries.
+        saml_response = auth_response(session_id, 'student')
+        response = self.client.post(reverse('saml2_acs'), {
+            'SAMLResponse': self.b64_for_post(saml_response),
+            'RelayState': came_from,
+        })
+        self.assertEqual(response.status_code, 403)
+
     def test_missing_param_to_assertion_consumer_service_request(self):
         # Send request without SAML2Response parameter
         response = self.client.post(reverse('saml2_acs'))

--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -217,8 +217,6 @@ class SAML2Tests(TestCase):
             metadata_file='remote_metadata_one_idp.xml',
         )
 
-        self.init_cookies()
-
         # session_id should start with a letter since it is a NCName
         session_id = "a0123456789abcdef0123456789abcdef"
         came_from = '/another-view/'

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -45,7 +45,10 @@ from saml2.metadata import entity_descriptor
 from saml2.ident import code, decode
 from saml2.sigver import MissingKey
 from saml2.s_utils import UnsupportedBinding
-from saml2.response import StatusError, StatusAuthnFailed, SignatureError, StatusRequestDenied
+from saml2.response import (
+    StatusError, StatusAuthnFailed, SignatureError, StatusRequestDenied,
+    UnsolicitedResponse,
+)
 from saml2.validate import ResponseLifetimeExceed, ToEarly
 from saml2.xmldsig import SIG_RSA_SHA1, SIG_RSA_SHA256  # support for SHA1 is required by spec
 
@@ -286,6 +289,9 @@ def assertion_consumer_service(request,
         return fail_acs_response(request)
     except MissingKey:
         logger.exception("SAML Identity Provider is not configured correctly: certificate key is missing!")
+        return fail_acs_response(request)
+    except UnsolicitedResponse:
+        logger.exception("Received SAMLResponse when no request has been made.")
         return fail_acs_response(request)
 
     if response is None:


### PR DESCRIPTION
Attempting to replay a SAMLResponse makes PySAML raise an
UnsolicitedResponse exception. That exception should be caught to
properly display an error instead of generating a server error.