### PR TITLE
Add enum as a dependency for Python <= 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
     install_requires=[
         'defusedxml>=0.4.1',
         'Django>=1.8',
+        'enum34;python_version > "3" and python_version < "3.4"',
         'pysaml2==4.4.0',
         ],
     extras_require=extra,


### PR DESCRIPTION
Travis builds for python 3.3 failed with:
`AttributeError: 'module' object has no attribute 'tests'`

The actual error was an ImportError. Running `python manage.py shell`:

```python
Python 3.3.7 (default, Oct 11 2017, 10:46:42)
>>> import djangosaml2.tests
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/dev/djangosaml2/djangosaml2/tests/__init__.py", line 44, in <module>
    from saml2.config import SPConfig
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/saml2/config.py", line 21, in <module>
    from saml2.mdstore import MetadataStore
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/saml2/mdstore.py", line 26, in <module>
    from saml2.httpbase import HTTPBase
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/saml2/httpbase.py", line 13, in <module>
    from saml2.pack import http_form_post_message
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/saml2/pack.py", line 19, in <module>
    from saml2.sigver import REQ_ORDER
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/saml2/sigver.py", line 8, in <module>
    from OpenSSL import crypto
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/OpenSSL/crypto.py", line 12, in <module>
    from cryptography import x509
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/cryptography/x509/__init__.py", line 7, in <module>
    from cryptography.x509 import certificate_transparency
  File "/.virtualenvs/djangosaml2-py33/lib/python3.3/site-packages/cryptography/x509/certificate_transparency.py", line 8, in <module>
    from enum import Enum
ImportError: No module named 'enum'
```