### PR TITLE
Re-enable tox build for django master

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,5 @@ deps =
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     .[test]
 
-# Waiting on upstream fix for https://code.djangoproject.com/ticket/28679
 ignore_outcome =
     djangomaster: True


### PR DESCRIPTION
https://code.djangoproject.com/ticket/28679 has been merged, the build
should pass on Django master.