### PR TITLE
Logger for non-saml2 authentication attempts from error to info

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -64,10 +64,10 @@ class Saml2Backend(ModelBackend):
     def authenticate(self, request, session_info=None, attribute_mapping=None,
                      create_unknown_user=True, **kwargs):
         if session_info is None or attribute_mapping is None:
-            logger.error('Session info or attribute mapping are None')
+            logger.info('Session info or attribute mapping are None')
             return None
 
-        if not 'ava' in session_info:
+        if 'ava' not in session_info:
             logger.error('"ava" key not found in session_info')
             return None
 


### PR DESCRIPTION
We use both the django modelbackend and the saml2 backend in the project to allow multiple ways of logging in. So in our settings we have 

```python
AUTHENTICATION_BACKENDS = (
    'django.contrib.auth.backends.ModelBackend',
    'djangosaml2.backends.Saml2Backend',
)
```

Due to the way Django works, it will try a fallthrough to the `Saml2Backend` if the `ModelBackend` fails. This means that normal username/password attempts end up in the `Saml2Backend` as well. This leads to our logs being flooded unnecessary with error-level logs. It is in fact simply not a request from a Saml2 flow, which is passed to it, and should just be discarded without logging an error. We cannot simply discard all error-logs from djangosaml2, as some of them are actual errors which we should keep.

This PR therefor changes that loglevel from error to info.