### PR TITLE
Upgrade to pysaml 4.5

### DIFF
--- a/djangosaml2/tests/conf.py
+++ b/djangosaml2/tests/conf.py
@@ -53,7 +53,8 @@ def create_conf(sp_host='sp.example.com', idp_hosts=['idp.example.com'],
                     },
                 'required_attributes': ['uid'],
                 'optional_attributes': ['eduPersonAffiliation'],
-                'idp': {}  # this is filled later
+                'idp': {},  # this is filled later
+                'want_response_signed': False,
                 },
             },
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'defusedxml>=0.4.1',
         'Django>=1.8',
         'enum34;python_version > "3" and python_version < "3.4"',
-        'pysaml2==4.4.0',
+        'pysaml2==4.5.0',
         ],
     extras_require=extra,
     )


### PR DESCRIPTION
1. `want_response_signed` now defaults to True instead of False, so we have to explicitly set it to `False` for our tests. 
3. This [commit](https://github.com/IdentityPython/pysaml2/commit/8c2b0529efce45b94209da938c89ebdf0a79748d) is the one that breaks tests. It took me a while to `git bisect` all the changes in the pysaml release to figure it out. It only breaks python3 because [defusedxml monkey patches ElementTree on Python3](https://github.com/tiran/defusedxml/blob/master/defusedxml/ElementTree.py#L32-L53). djangosaml2 tries to globally set the namespace values by setting them directly on ElementTree, but that object is no longer used. I changed it to more directly set the namespaces using the pysaml API.

With these changes, all unit tests pass on all python and django versions.
![image](https://user-images.githubusercontent.com/4413/39136701-d083dad4-46e9-11e8-8630-c60a78dc679e.png)