### PR TITLE
Update pysaml2 to 4.6.0 (or higher) to fix CVE-2017-1000246

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     install_requires=[
         'defusedxml>=0.4.1',
         'Django>=1.8',
-        'pysaml2==4.5.0',
+        'pysaml2>=4.6.0',
         ],
     extras_require=extra,
     )


### PR DESCRIPTION
See https://github.com/IdentityPython/pysaml2/issues/417 for the pysaml2 issue.

This changes the pysaml2 dependency from `==4.5` to `>=4.6`.

- 4.5 to 4.6 because 4.5 has the CVE.
- `==` to `>=` so that a PR like this won't be required in future.