### PR TITLE
More extensible view for assertion consumer service

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@ Changes
 - py38 Test fixes
 - CI with Github actions
 - Backend restructuring for easier subclassing
+- Assertion consumer service now more extensible as a class-based view
+  with hooks that can be overridden by subclass implementations.
 
 0.18.1 (2020-02-15)
 ----------

--- a/djangosaml2/tests/urls.py
+++ b/djangosaml2/tests/urls.py
@@ -20,7 +20,7 @@ from djangosaml2 import views
 
 urlpatterns = [
     url(r'^login/$', views.login, name='saml2_login'),
-    url(r'^acs/$', views.assertion_consumer_service, name='saml2_acs'),
+    url(r'^acs/$', views.AssertionConsumerServiceView.as_view(), name='saml2_acs'),
     url(r'^logout/$', views.logout, name='saml2_logout'),
     url(r'^ls/$', views.logout_service, name='saml2_ls'),
     url(r'^ls/post/$', views.logout_service_post, name='saml2_ls_post'),

--- a/djangosaml2/urls.py
+++ b/djangosaml2/urls.py
@@ -19,7 +19,7 @@ from . import views
 
 urlpatterns = [
     path('login/', views.login, name='saml2_login'),
-    path('acs/', views.assertion_consumer_service, name='saml2_acs'),
+    path('acs/', views.AssertionConsumerServiceView.as_view(), name='saml2_acs'),
     path('logout/', views.logout, name='saml2_logout'),
     path('ls/', views.logout_service, name='saml2_ls'),
     path('ls/post/', views.logout_service_post, name='saml2_ls_post'),


### PR DESCRIPTION
The assertion consumer service is now more extensible as a class-based view with hooks that can be overridden by subclass implementations.