### PR TITLE
Updates _sp_authn_requests_signed_alg to work with multiple bindings

### DIFF
--- a/djangosaml2/overrides.py
+++ b/djangosaml2/overrides.py
@@ -21,4 +21,11 @@ class Saml2Client(saml2.client.Saml2Client):
             except AttributeError:
                 logger.warning('SAML_LOGOUT_REQUEST_PREFERRED_BINDING setting is'
                     ' not defined. Default binding will be used.')
+
+        # 1. global_logout calls do_logout but does not forward kwargs, so we cannot use global_logout(sigalg=sigalg)
+        # 2. sigalg is used by BINDING_HTTP_REDIRECT
+        if kwargs.get('sign_alg') and not kwargs.get('sigalg'):
+            logger.debug("Setting sigalg: %s", kwargs.get('sign_alg'))
+            kwargs['sigalg'] = kwargs.get('sign_alg')
+
         return super(Saml2Client, self).do_logout(*args, **kwargs)


### PR DESCRIPTION
`_sp_authn_requests_signed_alg` allows overriding the algorithm used with _SignatureMethod_ but currently only works with the `BINDING_HTTP_REDIRECT`. This change enables its use for both `BINDING_HTTP_REDIRECT` and `BINDING_HTTP_POST`, during login and its use during logout.

The motivation for this change is ADFS defaults to requiring SHA256.

This change was tested with _Apache Shibboleth_ and _ADFS_ on _Windows Server 2012_.