### PR TITLE
Django custom attribute map for standard user model, other minor changes

### DIFF
--- a/djangosaml2/tests/attribute-maps/django_saml_uri.py
+++ b/djangosaml2/tests/attribute-maps/django_saml_uri.py
@@ -1,0 +1,19 @@
+X500ATTR_OID = 'urn:oid:2.5.4.'
+PKCS_9 = 'urn:oid:1.2.840.113549.1.9.1.'
+UCL_DIR_PILOT = 'urn:oid:0.9.2342.19200300.100.1.'
+
+MAP = {
+    'identifier': 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+    'fro': {
+        X500ATTR_OID+'3': 'first_name', # cn
+        X500ATTR_OID+'4': 'last_name', # sn
+        PKCS_9+'1': 'email',
+        UCL_DIR_PILOT+'1': 'uid',
+    },
+    'to': {
+        'first_name': X500ATTR_OID+'3',
+        'last_name': X500ATTR_OID+'4',
+        'email' : PKCS_9+'1',
+        'uid': UCL_DIR_PILOT+'1',
+    }
+}

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -144,7 +144,10 @@ def login(request,
                 'available_idps': idps.items(),
                 'came_from': came_from,
                 })
-
+    else:
+        # is the first one, otherwise next logger message will print None
+        selected_idp = list(idps.keys())[0]
+    
     # choose a binding to try first
     sign_requests = getattr(conf, '_sp_authn_requests_signed', False)
     binding = BINDING_HTTP_POST if sign_requests else BINDING_HTTP_REDIRECT


### PR DESCRIPTION
These minor changes permit:

- django standard User.models field to be used with a standard djangosaml2idp implementation;
- djangosaml2.login, logger now print at least the one IDP where is going to AuthnRequest