### PR TITLE
PR to add in flexibility for saml redirect hosts.

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -110,8 +110,14 @@ def login(request,
         came_from = settings.LOGIN_REDIRECT_URL
 
     # Ensure the user-originating redirection url is safe.
-    if not is_safe_url_compat(url=came_from, allowed_hosts={request.get_host()}):
+    # By setting SAML_ALLOWED_HOSTS in settings.py the user may provide a list of "allowed"
+    # hostnames for post-login redirects, much like one would specify ALLOWED_HOSTS .
+    # If this setting is absent, the default is to use the hostname that was used for the current
+    # request.
+    saml_allowed_hosts = set(getattr(settings, 'SAML_ALLOWED_HOSTS', [request.get_host()]))
+    if not is_safe_url_compat(url=came_from, allowed_hosts=saml_allowed_hosts):
         came_from = settings.LOGIN_REDIRECT_URL
+
 
     # if the user is already authenticated that maybe because of two reasons:
     # A) He has this URL in two browser windows and in the other one he

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='djangosaml2',
-    version='0.17.2',
+    version='0.17.3',
     description='pysaml2 integration for Django',
     long_description='\n\n'.join([read('README.rst'), read('CHANGES')]),
     classifiers=[
@@ -61,8 +61,8 @@ setup(
     author="Yaco Sistemas and independent contributors",
     author_email="lgs@yaco.es",
     maintainer="Jozef Knaperek",
-    url="https://github.com/knaperek/djangosaml2",
-    download_url="https://pypi.python.org/pypi/djangosaml2",
+    url="https://github.com/chander/djangosaml2.git",
+    download_url="https://github.com/chander/djangosaml2.git",
     license='Apache 2.0',
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,


### PR DESCRIPTION
This PR adds the ability for the user to allow external redirect hosts using the SAML_ALLOWED_HOSTS setting.  With this setting the user may allow additional hostnames to be use with the ?next= parameter, instead of being tied to just the current hostname that was used for the request.

It's the analog of ALLOWED_HOSTS, which IMHO ought to be the default for this setting, but isn't I suspect for historic reasons tied to the pre-1.11 implementation of the safe url check function.