### PR TITLE
forceauthn and allowcreate support

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -136,6 +136,13 @@ def login(request,
     selected_idp = request.GET.get('idp', None)
     conf = get_config(config_loader_path, request)
 
+    kwargs = {}
+    # pysaml needs a string otherwise: "cannot serialize True (type bool)"
+    if getattr(conf, '_sp_force_authn'):
+        kwargs['force_authn'] = "true"
+    if getattr(conf, '_sp_allow_create', "false"):
+        kwargs['allow_create'] = "true"
+
     # is a embedded wayf needed?
     idps = available_idps(conf)
     if selected_idp is None and len(idps) > 1:
@@ -184,7 +191,7 @@ def login(request,
             session_id, result = client.prepare_for_authenticate(
                 entityid=selected_idp, relay_state=came_from,
                 binding=binding, sign=False, sigalg=sigalg,
-                nsprefix=nsprefix)
+                nsprefix=nsprefix, **kwargs)
         except TypeError as e:
             logger.error('Unable to know which IdP to use')
             return HttpResponse(text_type(e))
@@ -200,7 +207,8 @@ def login(request,
                 return HttpResponse(text_type(e))
             session_id, request_xml = client.create_authn_request(
                 location,
-                binding=binding)
+                binding=binding,
+                **kwargs)
             try:
                 if PY3:
                     saml_request = base64.b64encode(binary_type(request_xml, 'UTF-8'))


### PR DESCRIPTION
ForceAuthn and AllowCreate support in djangosaml2, enable this features in authnRequest.
This also introduce kwargs, usefull to generalize other arguments in pySAML2 calls.

now when we configure `force_authn` and `name_id_format_allow_create` in pySAML2 sp configuration, the authn requests will manage them.

Example:

````
SAML_CONFIG = {
    'debug' : True,
    'xmlsec_binary': get_xmlsec_binary(['/opt/local/bin',
                                        '/usr/bin/xmlsec1']),
    'entityid': '%s/metadata/' % BASE_URL,

    'attribute_map_dir': os.path.join(os.path.join(os.path.join(BASE_DIR,
                                                                'saml2_sp'),
                                      'saml2_config'),
                                      'attribute-maps'),

    'service': {
        'sp': {
            'name': '%s/metadata/' % BASE_URL,

            'name_id_format': [NAMEID_FORMAT_PERSISTENT,
                                          NAMEID_FORMAT_TRANSIENT],

            'endpoints': {
                'assertion_consumer_service': [
                    ('%s/acs/' % BASE_URL, saml2.BINDING_HTTP_POST),
                    ],
                "single_logout_service": [
                    ("%s/ls/post/" % BASE_URL, saml2.BINDING_HTTP_POST),
                    ("%s/ls/" % BASE_URL, saml2.BINDING_HTTP_REDIRECT),
                ],
                }, # end endpoints

            # Mandates that the identity provider MUST authenticate the
            # presenter directly rather than rely on a previous security context.
            "force_authn": False, # SPID
            'name_id_format_allow_create': False,

````