### PR TITLE
add decode to fix template containing b' prefix

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -203,7 +203,7 @@ def login(request,
                 binding=binding)
             try:
                 if PY3:
-                    saml_request = base64.b64encode(binary_type(request_xml, 'UTF-8'))
+                    saml_request = base64.b64encode(binary_type(request_xml, 'UTF-8')).decode('utf-8')
                 else:
                     saml_request = base64.b64encode(binary_type(request_xml))
 


### PR DESCRIPTION
On python 3, a bytes object (result from `base64.b64encode`) is passed to the template, which gets rendered with a `b'` prefix, and that gets submitted in the POST data to the IdP: 

![image](https://user-images.githubusercontent.com/8758073/65309020-8d5b0380-db8b-11e9-8113-006bef5a649f.png)

This breaks login, as that message can't be base64decoded by the Idp. This MR converts the bytes to a string object using the `decode` function.