### PR TITLE
Fix IDP POST response for IDP initialized logout request (for SLO)

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -458,7 +458,17 @@ def do_logout_service(request, data, binding, config_loader_path=None, next_page
                 relay_state=data.get('RelayState', ''))
             state.sync()
             auth.logout(request)
-            return HttpResponseRedirect(get_location(http_info))
+            if (
+                http_info.get('method', 'GET') == 'POST' and
+                'data' in http_info and
+                ('Content-type', 'text/html') in http_info.get('headers', [])
+            ):
+                # need to send back to the IDP a signed POST response with user session
+                # return HTML form content to browser with auto form validation
+                # to finally send request to the IDP
+                return HttpResponse(http_info['data'])
+            else:
+                return HttpResponseRedirect(get_location(http_info))
     else:
         logger.error('No SAMLResponse or SAMLRequest parameter found')
         raise Http404('No SAMLResponse or SAMLRequest parameter found')


### PR DESCRIPTION
Currently, when receiving a logout started by the IdP, this app send back a simple HTTP redirection to the IDP without any data.  
When using Signed request/response, it results a `400` HTTP response from th IDP (Keycloak in my case).

![Capture d’écran_2019-09-25_11-09-39](https://user-images.githubusercontent.com/4538884/65684703-9272f380-e060-11e9-84c0-143a254e2893.png)

This PR tests if the `http_info` prepared by `SAML2Client.handle_logout_request` is an HTML Post form. In this case, we just return this HTML which will be submited by the browser to the IDP to confirm the SLO request has been done for this SP.