### PR TITLE
Fix unsigned authentication request to POST endpoint

### DIFF
--- a/djangosaml2/tests/conf.py
+++ b/djangosaml2/tests/conf.py
@@ -19,7 +19,7 @@ import saml2
 
 
 def create_conf(sp_host='sp.example.com', idp_hosts=['idp.example.com'],
-                metadata_file='remote_metadata.xml'):
+                metadata_file='remote_metadata.xml', authn_requests_signed=True):
 
     try:
         from saml2.sigver import get_xmlsec_binary
@@ -55,6 +55,7 @@ def create_conf(sp_host='sp.example.com', idp_hosts=['idp.example.com'],
                 'optional_attributes': ['eduPersonAffiliation'],
                 'idp': {},  # this is filled later
                 'want_response_signed': False,
+                'authn_requests_signed': authn_requests_signed,
                 },
             },
 

--- a/djangosaml2/tests/remote_metadata_post_binding.xml
+++ b/djangosaml2/tests/remote_metadata_post_binding.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <md:EntityDescriptor entityID="https://idp.example.com/simplesaml/saml2/idp/metadata.php">
+    <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+      <md:KeyDescriptor use="signing">
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+          <ds:X509Data>
+            <ds:X509Certificate>MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo</ds:X509Certificate>
+          </ds:X509Data>
+        </ds:KeyInfo>
+      </md:KeyDescriptor>
+      <md:KeyDescriptor use="encryption">
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+          <ds:X509Data>
+            <ds:X509Certificate>MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo</ds:X509Certificate>
+          </ds:X509Data>
+        </ds:KeyInfo>
+      </md:KeyDescriptor>
+      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php"/>
+      <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/simplesaml/saml2/idp/SSOService.php"/>
+    </md:IDPSSODescriptor>
+    <md:Organization>
+      <md:OrganizationName xml:lang="en">Lorenzo's test IdP</md:OrganizationName>
+      <md:OrganizationDisplayName xml:lang="en">idp.example.com IdP</md:OrganizationDisplayName>
+      <md:OrganizationURL xml:lang="en">http://idp.example.com/</md:OrganizationURL>
+    </md:Organization>
+    <md:ContactPerson contactType="technical">
+      <md:SurName>Administrator</md:SurName>
+      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+    </md:ContactPerson>
+  </md:EntityDescriptor>
+</md:EntitiesDescriptor>

--- a/djangosaml2/tests/utils.py
+++ b/djangosaml2/tests/utils.py
@@ -1,0 +1,16 @@
+from html.parser import HTMLParser
+
+
+class SAMLPostFormParser(HTMLParser):
+    """
+    Parses the SAML Post binding form page for the SAMLRequest value.
+    """
+
+    saml_request_value = None
+
+    def handle_starttag(self, tag, attrs):
+        attrs_dict = dict(attrs)
+
+        if tag != "input" or attrs_dict.get("name") != "SAMLRequest":
+            return
+        self.saml_request_value = attrs_dict.get("value")

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -37,6 +37,7 @@ from saml2.response import (SignatureError, StatusAuthnFailed, StatusError,
                             UnsolicitedResponse)
 from saml2.s_utils import UnsupportedBinding
 from saml2.sigver import MissingKey
+from saml2.samlp import AuthnRequest
 from saml2.validate import ResponseLifetimeExceed, ToEarly
 from saml2.xmldsig import (  # support for SHA1 is required by spec
     SIG_RSA_SHA1, SIG_RSA_SHA256)
@@ -205,6 +206,9 @@ def login(request,
                 binding=binding,
                 **kwargs)
             try:
+                if isinstance(request_xml, AuthnRequest):
+                    # request_xml will be an instance of AuthnRequest if the message is not signed
+                    request_xml = str(request_xml)
                 saml_request = base64.b64encode(bytes(request_xml, 'UTF-8')).decode('utf-8')
 
                 http_response = render(request, post_binding_form_template, {


### PR DESCRIPTION
* Fix error casting request_xml to bytes when request_xml is an object
  * If the message does not get signed, pysaml2 will return an AuthNRequest object which can't be casted to a binary
  * Related to https://github.com/IdentityPython/pysaml2/issues/570

Fixes #168 