### PR TITLE
Add to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,7 +192,13 @@ We will see a typical configuration for protecting a Django project::
                      saml2.BINDING_HTTP_POST),
                     ],
                 },
-
+             # Mandates that the identity provider MUST authenticate the
+             # presenter directly rather than rely on a previous security context.
+            'force_authn': False, 
+            
+             # Enable AllowCreate in NameIDPolicy.
+            'name_id_format_allow_create': False,
+            
              # attributes that this project need to identify a user
             'required_attributes': ['uid'],
 

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -147,7 +147,7 @@ def login(request,
 
     kwargs = {}
     # pysaml needs a string otherwise: "cannot serialize True (type bool)"
-    if getattr(conf, '_sp_force_authn'):
+    if getattr(conf, '_sp_force_authn',False):
         kwargs['force_authn'] = "true"
     if getattr(conf, '_sp_allow_create', "false"):
         kwargs['allow_create'] = "true"

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -147,7 +147,7 @@ def login(request,
 
     kwargs = {}
     # pysaml needs a string otherwise: "cannot serialize True (type bool)"
-    if getattr(conf, '_sp_force_authn',False):
+    if getattr(conf, '_sp_force_authn'):
         kwargs['force_authn'] = "true"
     if getattr(conf, '_sp_allow_create', "false"):
         kwargs['allow_create'] = "true"


### PR DESCRIPTION
Added `force_authn` and `name_id_format_allow_create` to the documentation.
In addition, added a default value for `if getattr(conf, '_sp_force_authn'):` this way if the user does not specify `'force_authn'` in the configuration the library would still work  without any problems.