### PR TITLE
Code update and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@
 *.sqp
 build/
 dist/
+_build/
+.pytest_cache
+.env
+env/
+venv
+tags
+.idea/
+.vscode/

--- a/.hgignore
+++ b/.hgignore
@@ -1,9 +1,0 @@
-syntax: glob
-
-*.egg-info
-build
-dist
-*.pyc
-*.swp
-*.swo
-.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,52 +5,31 @@ sudo: false
 
 matrix:
   include:
-    - python: 2.7
-      env: TOX_ENV=py27-django18
-    - python: 2.7
-      env: TOX_ENV=py27-django19
-    - python: 3.5
-      env: TOX_ENV=py35-django19
-    - python: 2.7
-      env: TOX_ENV=py27-django110
-    - python: 3.5
-      env: TOX_ENV=py35-django110
-    - python: 2.7
-      env: TOX_ENV=py27-django111
-    - python: 3.5
-      env: TOX_ENV=py35-django111
-    - python: 3.6
-      env: TOX_ENV=py36-django111
-    - python: 3.5
-      env: TOX_ENV=py35-django20
-    - python: 3.6
-      env: TOX_ENV=py36-django20
-    - python: 3.7
-      env: TOX_ENV=py37-django20
-    - python: 3.5
-      env: TOX_ENV=py35-django21
-    - python: 3.6
-      env: TOX_ENV=py36-django21
-    - python: 3.7
-      env: TOX_ENV=py37-django21
     - python: 3.5
       env: TOX_ENV=py35-django22
     - python: 3.6
       env: TOX_ENV=py36-django22
     - python: 3.7
       env: TOX_ENV=py37-django22
+    - python: 3.8
+      env: TOX_ENV=py38-django22
     - python: 3.6
       env: TOX_ENV=py36-django30
     - python: 3.7
       env: TOX_ENV=py37-django30
+    - python: 3.8
+      env: TOX_ENV=py38-django30
     - python: 3.6
       env: TOX_ENV=py36-djangomaster
     - python: 3.7
       env: TOX_ENV=py37-djangomaster
+    - python: 3.8
+      env: TOX_ENV=py38-djangomaster
   fast_finish: true
   allow_failures:
     - env: TOX_ENV=py36-djangomaster
     - env: TOX_ENV=py37-djangomaster
+    - env: TOX_ENV=py38-djangomaster
 
 addons:
   apt:

--- a/djangosaml2/__init__.py
+++ b/djangosaml2/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'djangosaml2.apps.DjangoSaml2Config'

--- a/djangosaml2/acs_failures.py
+++ b/djangosaml2/acs_failures.py
@@ -3,7 +3,6 @@
 # This module defines a set of useful ACS failure functions that are used to
 # produce an output suitable for end user in case of SAML failure.
 #
-from __future__ import unicode_literals
 
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import render

--- a/djangosaml2/apps.py
+++ b/djangosaml2/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class DjangoSaml2Config(AppConfig):
+    name = 'djangosaml2'
+    verbose_name = "DjangoSAML2"
+
+    def ready(self):
+        from . import signals  # noqa

--- a/djangosaml2/cache.py
+++ b/djangosaml2/cache.py
@@ -25,7 +25,7 @@ class DjangoSessionCacheAdapter(dict):
         self.session = django_session
         self.key = self.key_prefix + key_suffix
 
-        super(DjangoSessionCacheAdapter, self).__init__(self._get_objects())
+        super().__init__(self._get_objects())
 
     def _get_objects(self):
         return self.session.get(self.key, {})
@@ -37,9 +37,9 @@ class DjangoSessionCacheAdapter(dict):
         # Changes in inner objects do not cause session invalidation
         # https://docs.djangoproject.com/en/1.9/topics/http/sessions/#when-sessions-are-saved
 
-        #add objects to session
+        # add objects to session
         self._set_objects(dict(self))
-        #invalidate session
+        # invalidate session
         self.session.modified = True
 
 
@@ -49,8 +49,7 @@ class OutstandingQueriesCache(object):
     """
 
     def __init__(self, django_session):
-        self._db = DjangoSessionCacheAdapter(django_session,
-                                             '_outstanding_queries')
+        self._db = DjangoSessionCacheAdapter(django_session, '_outstanding_queries')
 
     def outstanding_queries(self):
         return self._db._get_objects()
@@ -86,4 +85,4 @@ class StateCache(DjangoSessionCacheAdapter):
     """
 
     def __init__(self, django_session):
-        super(StateCache, self).__init__(django_session, '_state')
+        super().__init__(django_session, '_state')

--- a/djangosaml2/conf.py
+++ b/djangosaml2/conf.py
@@ -18,10 +18,9 @@ from importlib import import_module
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-
 from saml2.config import SPConfig
 
-from djangosaml2.utils import get_custom_setting
+from .utils import get_custom_setting
 
 
 def get_config_loader(path, request=None):

--- a/djangosaml2/models.py
+++ b/djangosaml2/models.py
@@ -1,1 +1,0 @@
-# nothing here, just an empty file to avoid Django complaints

--- a/djangosaml2/overrides.py
+++ b/djangosaml2/overrides.py
@@ -21,4 +21,4 @@ class Saml2Client(saml2.client.Saml2Client):
             except AttributeError:
                 logger.warning('SAML_LOGOUT_REQUEST_PREFERRED_BINDING setting is'
                     ' not defined. Default binding will be used.')
-        return super(Saml2Client, self).do_logout(*args, **kwargs)
+        return super().do_logout(*args, **kwargs)

--- a/djangosaml2/signals.py
+++ b/djangosaml2/signals.py
@@ -14,7 +14,5 @@
 
 import django.dispatch
 
-
-pre_user_save = django.dispatch.Signal(providing_args=['attributes',
-                                                       'user_modified'])
+pre_user_save = django.dispatch.Signal(providing_args=['attributes', 'user_modified'])
 post_authenticated = django.dispatch.Signal(providing_args=['session_info'])

--- a/djangosaml2/urls.py
+++ b/djangosaml2/urls.py
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
-from djangosaml2 import views
+from django.urls import path
 
+from . import views
 
 urlpatterns = [
-    url(r'^login/$', views.login, name='saml2_login'),
-    url(r'^acs/$', views.assertion_consumer_service, name='saml2_acs'),
-    url(r'^logout/$', views.logout, name='saml2_logout'),
-    url(r'^ls/$', views.logout_service, name='saml2_ls'),
-    url(r'^ls/post/$', views.logout_service_post, name='saml2_ls_post'),
-    url(r'^metadata/$', views.metadata, name='saml2_metadata'),
+    path('login/', views.login, name='saml2_login'),
+    path('acs/', views.assertion_consumer_service, name='saml2_acs'),
+    path('logout/', views.logout, name='saml2_logout'),
+    path('ls/', views.logout_service, name='saml2_ls'),
+    path('ls/post/', views.logout_service_post, name='saml2_ls_post'),
+    path('metadata/', views.metadata, name='saml2_metadata'),
 ]

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.http import is_safe_url
 from django.utils.module_loading import import_string
 from saml2.s_utils import UnknownSystemEntity
 
@@ -33,9 +31,12 @@ def available_idps(config, langpref=None):
     for metadata_name, metadata in config.metadata.metadata.items():
         result = metadata.any('idpsso_descriptor', 'single_sign_on_service')
         if result:
-            idps = idps.union(set(result.keys()))
+            idps.update(result.keys())
 
-    return dict([(idp, config.metadata.name(idp, langpref)) for idp in idps])
+    return {
+        idp: config.metadata.name(idp, langpref)
+        for idp in idps
+    }
 
 
 def get_idp_sso_supported_bindings(idp_entity_id=None, config=None):
@@ -43,13 +44,12 @@ def get_idp_sso_supported_bindings(idp_entity_id=None, config=None):
     This is not clear in the pysaml2 code, so wrapping it in a util"""
     if config is None:
         # avoid circular import
-        from djangosaml2.conf import get_config
+        from .conf import get_config
         config = get_config()
     # load metadata store from config
     meta = getattr(config, 'metadata', {})
     # if idp is None, assume only one exists so just use that
     if idp_entity_id is None:
-        # .keys() returns dict_keys in python3.5+
         try:
             idp_entity_id = list(available_idps(config).keys())[0]
         except IndexError:
@@ -80,11 +80,3 @@ def fail_acs_response(request, *args, **kwargs):
     failure_function = import_string(get_custom_setting('SAML_ACS_FAILURE_RESPONSE_FUNCTION',
                                                         'djangosaml2.acs_failures.template_failure'))
     return failure_function(request, *args, **kwargs)
-
-
-def is_safe_url_compat(url, allowed_hosts=None, require_https=False):
-    if django.VERSION >= (1, 11):
-        return is_safe_url(url, allowed_hosts=allowed_hosts, require_https=require_https)
-    assert len(allowed_hosts) == 1
-    host = allowed_hosts.pop()
-    return is_safe_url(url, host=host)

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -19,52 +19,41 @@ import logging
 from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied, SuspiciousOperation
+from django.http import HttpResponseBadRequest  # 40x
+from django.http import HttpResponseRedirect  # 30x
+from django.http import HttpResponseServerError  # 50x
+from django.http import Http404, HttpResponse
+from django.shortcuts import render
+from django.template import TemplateDoesNotExist
+from django.utils.http import is_safe_url
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT
+from saml2.ident import code, decode
+from saml2.metadata import entity_descriptor
+from saml2.response import (SignatureError, StatusAuthnFailed, StatusError,
+                            StatusNoAuthnContext, StatusRequestDenied,
+                            UnsolicitedResponse)
+from saml2.s_utils import UnsupportedBinding
+from saml2.sigver import MissingKey
+from saml2.validate import ResponseLifetimeExceed, ToEarly
+from saml2.xmldsig import (  # support for SHA1 is required by spec
+    SIG_RSA_SHA1, SIG_RSA_SHA256)
+
+from .cache import IdentityCache, OutstandingQueriesCache, StateCache
+from .conf import get_config
+from .exceptions import IdPConfigurationMissing
+from .overrides import Saml2Client
+from .signals import post_authenticated
+from .utils import (available_idps, fail_acs_response, get_custom_setting,
+                    get_idp_sso_supported_bindings, get_location)
+
 try:
     from django.contrib.auth.views import LogoutView
     django_logout = LogoutView.as_view()
 except ImportError:
     from django.contrib.auth.views import logout as django_logout
-from django.core.exceptions import PermissionDenied, SuspiciousOperation
-from django.http import Http404, HttpResponse
-from django.http import HttpResponseRedirect  # 30x
-from django.http import HttpResponseBadRequest  # 40x
-from django.http import HttpResponseServerError  # 50x
-from django.views.decorators.http import require_POST
-from django.shortcuts import render
-from django.template import TemplateDoesNotExist
-
-try:
-    from django.utils.six import text_type, binary_type, PY3
-except ImportError:
-    import sys
-    PY3 = sys.version_info[0] == 3
-    text_type = str
-    binary_type = bytes
-
-from django.views.decorators.csrf import csrf_exempt
-
-from saml2 import BINDING_HTTP_REDIRECT, BINDING_HTTP_POST
-from saml2.metadata import entity_descriptor
-from saml2.ident import code, decode
-from saml2.sigver import MissingKey
-from saml2.s_utils import UnsupportedBinding
-from saml2.response import (
-    StatusError, StatusAuthnFailed, SignatureError, StatusRequestDenied,
-    UnsolicitedResponse, StatusNoAuthnContext,
-)
-from saml2.validate import ResponseLifetimeExceed, ToEarly
-from saml2.xmldsig import SIG_RSA_SHA1, SIG_RSA_SHA256  # support for SHA1 is required by spec
-
-from djangosaml2.cache import IdentityCache, OutstandingQueriesCache
-from djangosaml2.cache import StateCache
-from djangosaml2.exceptions import IdPConfigurationMissing
-from djangosaml2.conf import get_config
-from djangosaml2.overrides import Saml2Client
-from djangosaml2.signals import post_authenticated
-from djangosaml2.utils import (
-    available_idps, fail_acs_response, get_custom_setting,
-    get_idp_sso_supported_bindings, get_location, is_safe_url_compat,
-)
 
 
 logger = logging.getLogger('djangosaml2')
@@ -79,16 +68,6 @@ def _get_subject_id(session):
         return decode(session['_saml2_subject_id'])
     except KeyError:
         return None
-
-
-def callable_bool(value):
-    """ A compatibility wrapper for pre Django 1.10 User model API that used
-    is_authenticated() and is_anonymous() methods instead of attributes
-    """
-    if callable(value):
-        return value()
-    else:
-        return value
 
 
 def login(request,
@@ -119,7 +98,7 @@ def login(request,
         came_from = settings.LOGIN_REDIRECT_URL
 
     # Ensure the user-originating redirection url is safe.
-    if not is_safe_url_compat(url=came_from, allowed_hosts={request.get_host()}):
+    if not is_safe_url(url=came_from, allowed_hosts={request.get_host()}):
         came_from = settings.LOGIN_REDIRECT_URL
 
     # if the user is already authenticated that maybe because of two reasons:
@@ -132,7 +111,7 @@ def login(request,
     # SAML_IGNORE_AUTHENTICATED_USERS_ON_LOGIN setting. If that setting
     # is True (default value) we will redirect him to the came_from view.
     # Otherwise, we will show an (configurable) authorization error.
-    if callable_bool(request.user.is_authenticated):
+    if request.user.is_authenticated:
         redirect_authenticated_user = getattr(settings, 'SAML_IGNORE_AUTHENTICATED_USERS_ON_LOGIN', True)
         if redirect_authenticated_user:
             return HttpResponseRedirect(came_from)
@@ -210,7 +189,7 @@ def login(request,
                 nsprefix=nsprefix, **kwargs)
         except TypeError as e:
             logger.error('Unable to know which IdP to use')
-            return HttpResponse(text_type(e))
+            return HttpResponse(str(e))
         else:
             http_response = HttpResponseRedirect(get_location(result))
     elif binding == BINDING_HTTP_POST:
@@ -220,16 +199,13 @@ def login(request,
                 location = client.sso_location(selected_idp, binding)
             except TypeError as e:
                 logger.error('Unable to know which IdP to use')
-                return HttpResponse(text_type(e))
+                return HttpResponse(str(e))
             session_id, request_xml = client.create_authn_request(
                 location,
                 binding=binding,
                 **kwargs)
             try:
-                if PY3:
-                    saml_request = base64.b64encode(binary_type(request_xml, 'UTF-8')).decode('utf-8')
-                else:
-                    saml_request = base64.b64encode(binary_type(request_xml))
+                saml_request = base64.b64encode(bytes(request_xml, 'UTF-8')).decode('utf-8')
 
                 http_response = render(request, post_binding_form_template, {
                     'target_url': location,
@@ -249,7 +225,7 @@ def login(request,
                     binding=binding)
             except TypeError as e:
                 logger.error('Unable to know which IdP to use')
-                return HttpResponse(text_type(e))
+                return HttpResponse(str(e))
             else:
                 http_response = HttpResponse(result['data'])
     else:
@@ -356,7 +332,7 @@ def assertion_consumer_service(request,
     if not relay_state:
         logger.warning('The RelayState parameter exists but is empty')
         relay_state = default_relay_state
-    if not is_safe_url_compat(url=relay_state, allowed_hosts={request.get_host()}):
+    if not is_safe_url(url=relay_state, allowed_hosts={request.get_host()}):
         relay_state = settings.LOGIN_REDIRECT_URL
     logger.debug('Redirecting to the RelayState: %s', relay_state)
     return HttpResponseRedirect(relay_state)
@@ -516,7 +492,7 @@ def metadata(request, config_loader_path=None, valid_for=None):
     """
     conf = get_config(config_loader_path, request)
     metadata = entity_descriptor(conf)
-    return HttpResponse(content=text_type(metadata).encode('utf-8'),
+    return HttpResponse(content=str(metadata).encode('utf-8'),
                         content_type="text/xml; charset=utf8")
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,39 +23,26 @@ def read(*rnames):
     return codecs.open(os.path.join(os.path.dirname(__file__), *rnames), encoding='utf-8').read()
 
 
-extra = {'test': []}
-if sys.version_info < (3, 4):
-    # Necessary to use assertLogs in tests
-    extra['test'].append('unittest2')
-
-
 setup(
     name='djangosaml2',
     version='0.18.1',
     description='pysaml2 integration for Django',
     long_description=read('README.rst'),
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 1.8",
-        "Framework :: Django :: 1.9",
-        "Framework :: Django :: 1.10",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI",
         "Topic :: Security",
@@ -73,8 +60,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'defusedxml>=0.4.1',
-        'Django>=1.8',
+        'Django>=2.2',
         'pysaml2>=4.6.0',
         ],
-    extras_require=extra,
     )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -46,9 +46,6 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
-if django.VERSION < (1, 10):
-    MIDDLEWARE_CLASSES = MIDDLEWARE
-
 ROOT_URLCONF = 'testprofiles.urls'
 
 TEMPLATES = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,14 @@
 [tox]
 envlist =
-    py{27,35}-django18
-    py{27,35}-django19
-    py{27,35}-django110
-    py{27,35,36}-django111
-    py{35,36,37}-django20
-    py{35,36,37}-django21
-    py{35,36,37}-django22
-    py{36,37}-django30
-    py{36,37}-djangomaster
+    py{35,36,37,38}-django22
+    py{36,37,38}-django30
+    py{36,37,38}-djangomaster
 
 [testenv]
 commands =
     python tests/run_tests.py
 
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Support for Python 2 has been finally stopped at the end of last year, and the only supported Django versions are 2.2 and 3.0 currently. This allows for some modernization and cleanup of the code. This MR's removes some compatibility-related code for old environments, and has some minor changes due to how things are done in the newer Django versions. No functionality changes are intented.