### PR TITLE
Customized error handling improved

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -315,6 +315,24 @@ setting::
   SAML_CONFIG_LOADER = 'python.path.to.your.callable'
 
 
+Custom error handler
+....................
+
+When an error occurs during the authentication flow, djangosaml2 will render
+a simple error page with an error message and status code. You can customize
+this behaviour by specifying the path to your own error handler in the settings:
+
+  SAML_ACS_FAILURE_RESPONSE_FUNCTION = 'python.path.to.your.view'
+
+This should be a view which takes a request, optional exception which occured
+and status code, and returns a response to serve the user. E.g. The default
+implementation looks like this::
+
+  def template_failure(request, exception=None, **kwargs):
+      """ Renders a simple template with an error message. """
+      return render(request, 'djangosaml2/login_error.html', {'exception': exception}, status=kwargs.get('status', 403))
+
+
 User attributes
 ---------------
 

--- a/djangosaml2/acs_failures.py
+++ b/djangosaml2/acs_failures.py
@@ -5,18 +5,9 @@
 #
 from __future__ import unicode_literals
 
-from django.core.exceptions import PermissionDenied
 from django.shortcuts import render
 
 
-def template_failure(request, status=403, **kwargs):
-    """ Renders a SAML-specific template with general authentication error description. """
-    return render(request, 'djangosaml2/login_error.html', status=status)
-
-
-def exception_failure(request, exc_class=PermissionDenied, **kwargs):
-    """ Rather than using a custom SAML specific template that is rendered on failure,
-    this makes use of a standard exception handling machinery present in Django
-    and thus ends up rendering a project-wide error page for Permission Denied exceptions.
-    """
-    raise exc_class
+def template_failure(request, exception=None, status=403, **kwargs):
+    """ Renders a simple template with an error message. """
+    return render(request, 'djangosaml2/login_error.html', {'exception': exception}, status=status)


### PR DESCRIPTION
The error handler can already be customized using a setting, which isn't documented. This adds a part to the readme about it, so people are aware.

The error views currently does not get any information about what went wrong, which is important to decide what to do when customizing the behaviour in your own view. This adds the exception instance that occurred as an argument to the error handler. The default handler doesn't do anything with it, which keeps the default behaviour the same as it is now.

Cleaned up some unused code.