### PR TITLE
Mitigate xss issue

### DIFF
--- a/djangosaml2/templates/djangosaml2/example_post_binding_form.html
+++ b/djangosaml2/templates/djangosaml2/example_post_binding_form.html
@@ -9,7 +9,7 @@ Please click the button below if you're not redirected automatically within a fe
 </p>
 <form method="post" action="{{ target_url }}" name="SSO_Login">
 	{% for key, value in params.items %}
-	    <input type="hidden" name="{{ key|safe }}" value="{{ value|safe }}" />
+	    <input type="hidden" name="{{ key }}" value="{{ value }}" />
 	{% endfor %}
     <input type="submit" value="Log in" />
 </form>


### PR DESCRIPTION
The example template for the form post is vulnerable to a reflective XSS attack, by injecting via the next parameter, e.g.:

    [your_host]/saml2/login/?idp=[something]?idpid=[something]&next=a"><img%20src=x%20onerror="alert(1)