### PR TITLE
Fix for #117 post_authenticated_signal

### DIFF
--- a/djangosaml2/signals.py
+++ b/djangosaml2/signals.py
@@ -15,4 +15,4 @@
 import django.dispatch
 
 pre_user_save = django.dispatch.Signal(providing_args=['attributes', 'user_modified'])
-post_authenticated = django.dispatch.Signal(providing_args=['session_info'])
+post_authenticated = django.dispatch.Signal(providing_args=['session_info', 'request'])

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -157,7 +157,7 @@ def login(request,
                                            'its metadata is expired.'))
         if selected_idp is None:
             selected_idp = list(idps.keys())[0]
-    
+
     # choose a binding to try first
     sign_requests = getattr(conf, '_sp_authn_requests_signed', False)
     binding = BINDING_HTTP_POST if sign_requests else BINDING_HTTP_REDIRECT
@@ -348,7 +348,12 @@ class AssertionConsumerServiceView(View):
         logger.debug("User %s authenticated via SSO.", user)
         logger.debug('Sending the post_authenticated signal')
 
-        post_authenticated.send_robust(sender=user, session_info=session_info)
+        # post_authenticated.send_robust(sender=user, session_info=session_info)
+        # https://github.com/knaperek/djangosaml2/issues/117
+        post_authenticated.send_robust(sender=user.__class__,
+                                       instance=user,
+                                       session_info=session_info,
+                                       request=request)
         self.customize_session(user, session_info)
 
         relay_state = self.build_relay_state()


### PR DESCRIPTION
Hi, I think this is the fix for https://github.com/knaperek/djangosaml2/issues/117. I do not have a test server for saml and my production server runs an older version of djangosaml2 which cannot be upgraded without significant rewrites (custom user lookup function and such). Therefore i was unable to test this code.