### PR TITLE
Allow no attributes in request

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Changes
 =======
 
+0.X.X (to-be-released)
+-------------------
+- Allow a SSO request without any attributes besides the NameID info. Backwards-incompatible changes to allow easier behaviour differentiation, two methods now receive the idp identifier (+ **kwargs were added to introduce possible similar changes in the future with less breaking effect):
+  - Method signature changed on Saml2Backend.clean_attributes: from `clean_attributes(self, attributes: dict)` to `clean_attributes(self, attributes: dict, idp_entityid: str, **kwargs)`
+  - Methodignature changed on Saml2Backend.is_authorized: from `is_authorized(self, attributes: dict, attribute_mapping: dict)` to `is_authorized(self, attributes: dict, attribute_mapping: dict, idp_entityid: str, **kwargs)`
+
 0.30.0 (2020-07-30)
 -------------------
 - SameSite workaround with a specialized cookie, decoupled from django default

--- a/tests/testprofiles/tests.py
+++ b/tests/testprofiles/tests.py
@@ -89,11 +89,11 @@ class Saml2BackendTests(TestCase):
             self.assertEqual(self.backend._user_lookup_attribute, 'username')
 
     def test_is_authorized(self):
-        self.assertTrue(self.backend.is_authorized({}, {}))
+        self.assertTrue(self.backend.is_authorized({}, {}, ''))
 
     def test_clean_attributes(self):
         attributes = {'random': 'dummy', 'value': 123}
-        self.assertEqual(self.backend.clean_attributes(attributes), attributes)
+        self.assertEqual(self.backend.clean_attributes(attributes, ''), attributes)
         
     def test_clean_user_main_attribute(self):
         self.assertEqual(self.backend.clean_user_main_attribute('value'), 'value')
@@ -273,11 +273,11 @@ class Saml2BackendTests(TestCase):
 class CustomizedBackend(Saml2Backend):
     """ Override the available methods with some customized implementation to test customization
     """
-    def is_authorized(self, attributes, attribute_mapping):
+    def is_authorized(self, attributes, attribute_mapping, idp_entityid: str, **kwargs):
         ''' Allow only staff users from the IDP '''
         return attributes.get('is_staff', (None, ))[0] == True
     
-    def clean_attributes(self, attributes: dict) -> dict:
+    def clean_attributes(self, attributes: dict, idp_entityid: str, **kwargs) -> dict:
         ''' Keep only age attribute '''
         return {
             'age': attributes.get('age', (None, )),
@@ -306,13 +306,13 @@ class CustomizedSaml2BackendTests(Saml2BackendTests):
             'cn': ('John', ),
             'sn': ('Doe', ),
             }
-        self.assertFalse(self.backend.is_authorized(attributes, attribute_mapping))
+        self.assertFalse(self.backend.is_authorized(attributes, attribute_mapping, ''))
         attributes['is_staff'] = (True, )
-        self.assertTrue(self.backend.is_authorized(attributes, attribute_mapping))
+        self.assertTrue(self.backend.is_authorized(attributes, attribute_mapping, ''))
 
     def test_clean_attributes(self):
         attributes = {'random': 'dummy', 'value': 123, 'age': '28'}
-        self.assertEqual(self.backend.clean_attributes(attributes), {'age': '28', 'is_staff': (None,), 'uid': (None,)})
+        self.assertEqual(self.backend.clean_attributes(attributes, ''), {'age': '28', 'is_staff': (None,), 'uid': (None,)})
         
     def test_clean_user_main_attribute(self):
         self.assertEqual(self.backend.clean_user_main_attribute('va--l__ u -e'), 'va__l___u__e')


### PR DESCRIPTION
Currently a request without any attributes besides the nameid information is wrongfully blocked from succeeding. I've removed the check after the call to `clean_attributes`, since an empty dict for attributes is not something wrong; if you want to block a request based on the content of the attributes, there is the `is_authorized` method to do so.