### PR TITLE
Catch SAML logout errors and display error view

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -518,7 +518,11 @@ def do_logout_service(request, data, binding, config_loader_path=None, next_page
 
     if 'SAMLResponse' in data:  # we started the logout
         logger.debug('Receiving a logout response from the IdP')
-        response = client.parse_logout_request_response(data['SAMLResponse'], binding)
+        try:
+            response = client.parse_logout_request_response(data['SAMLResponse'], binding)
+        except StatusError as e:
+            response = None
+            logger.warn("Error logging out from remote provider: " + str(e))
         state.sync()
         return finish_logout(request, response, next_page=next_page)
 


### PR DESCRIPTION
I am running Django 3.1.1 + PySAML 6.1.0 + djangosaml master

When trying to logout from the IDP after the SSO session has expired (but while the Django session is still valid), the IDP responds with the following status:

```
<ns0:Status xmlns:ns0="urn:oasis:names:tc:SAML:2.0:protocol"><ns0:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder"></ns0:StatusCode></ns0:Status>
```
and an exception is thrown in `client.parse_logout_request_response`, which is not catched by djangosaml and ends up with a HTTP code 500.

I propose to catch this exception and display a graceful error page in `finish_logout` instead.

My ultimate goal is to ignore this error, which I will propose in another PR, but it is a more controversial change, so I am proposing this one separately.