### PR TITLE
Add an option to ignore logout errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,13 @@ For example::
   import saml2
   SAML_LOGOUT_REQUEST_PREFERRED_BINDING = saml2.BINDING_HTTP_POST
 
+Ignore Logout errors
+--------------------
+When logging out, a SAML IDP will return an error on invalid conditions, such as the IDP-side session being expired.
+Use the following setting to ignore these errors and perform a local Django logout nonetheless::
+
+  SAML_IGNORE_LOGOUT_ERRORS = True
+
 Signed Logout Request
 ------------------------
 Idp's like Okta require a signed logout response to validate and logout a user. Here's a sample config with all required SP/IDP settings::

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -522,7 +522,7 @@ def do_logout_service(request, data, binding, config_loader_path=None, next_page
             response = client.parse_logout_request_response(data['SAMLResponse'], binding)
         except StatusError as e:
             response = None
-            logger.warn("Error logging out from remote provider: " + str(e))
+            logger.warning("Error logging out from remote provider: " + str(e))
         state.sync()
         return finish_logout(request, response, next_page=next_page)
 

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -561,7 +561,9 @@ def do_logout_service(request, data, binding, config_loader_path=None, next_page
 
 
 def finish_logout(request, response, next_page=None):
-    if response and response.status_ok():
+    if (getattr(settings, 'SAML_IGNORE_LOGOUT_ERRORS', False) or
+            (response and response.status_ok())):
+
         if next_page is None and hasattr(settings, 'LOGOUT_REDIRECT_URL'):
             next_page = settings.LOGOUT_REDIRECT_URL
         logger.debug('Performing django logout with a next_page of %s',


### PR DESCRIPTION
When the IDP session time is shorter than the Django session time, logout from Django will trigger an SAML logout error.

There are use cases, such as an IDP being used for a single application, where not being able to successfully logout from the IDP is not a big issue. So I am proposing an option that lets the Django logout flow continue even when SAML logout could not be performed successfully