### PR TITLE
Fix for overriding custom error view using SAML_ACS_FAILURE_RESPONSE_FUNCTION

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -388,9 +388,9 @@ This should be a view which takes a request, optional exception which occured
 and status code, and returns a response to serve the user. E.g. The default
 implementation looks like this::
 
-  def template_failure(request, exception=None, **kwargs):
+  def template_failure(request, exception=None, status=403, **kwargs):
       """ Renders a simple template with an error message. """
-      return render(request, 'djangosaml2/login_error.html', {'exception': exception}, status=kwargs.get('status', 403))
+      return render(request, 'djangosaml2/login_error.html', {'exception': exception}, status=status)
 
 
 User attributes

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -28,6 +28,7 @@ from django.template import TemplateDoesNotExist
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from django.utils.module_loading import import_string
 from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT
 from saml2.client_base import LogoutError
 from saml2.config import SPConfig


### PR DESCRIPTION
The custom error view call was using the `import_string` function but this function wasn't being imported in the file so it resulted in an error at runtime.

Additionally the documentation describing how to do this has a small error with the example function you need to override. I guess at some point in the past `status` was added as a positional argument.