### PR TITLE
Add session_info to user auth failed template

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -380,7 +380,8 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
                                  create_unknown_user=create_unknown_user)
         if user is None:
             logger.warning("Could not authenticate user received in SAML Assertion. Session info: %s", session_info)
-            return self.handle_acs_failure(request, exception=PermissionDenied('No user could be authenticated.'))
+            return self.handle_acs_failure(request, exception=PermissionDenied('No user could be authenticated.'),
+                                           session_info=session_info)
 
         auth.login(self.request, user)
         _set_subject_id(request.saml_session, session_info['name_id'])


### PR DESCRIPTION
This lets people customise the error page when a user fails to
authenticate with useful information if they wish.

There doesn't seem to be a nice way of getting hold of the SAML session information to be able to display this on the custom access denied page. Having written other things for SAML auth before I've found this really helpful for figuring out what's going wrong. Would you be willing to adjust the function call to `handle_acs_failure` to pass in this data?

Thanks.

