### PR TITLE
Documentation: Replace signal with hooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -510,25 +510,17 @@ https://docs.djangoproject.com/en/dev/topics/auth/customizing/#substituting-a-cu
 
 Sometimes you need to use special logic to update the user object
 depending on the SAML2 attributes and the mapping described above
-is simply not enough. For these cases djangosaml2 provides a Django
-signal that you can listen to. In order to do so you can add the
-following code to your app::
+is simply not enough. For these cases djangosaml2 provides hooks_
+that can be overriden with custom functionality. For example::
 
-  from djangosaml2.signals import pre_user_save
+  from djangosaml2.backends import Saml2Backend
 
-  def custom_update_user(sender=User, instance, attributes, user_modified, **kargs)
-     ...
-     return True  # I modified the user object
+  class MySaml2Backend(Saml2Backend):
+      def save_user(self, user, *args, **kwargs):
+          # Add custom logic here
+          return super().save_user(user, *args, **kwargs)
 
-
-Your handler will receive the user object, the list of SAML attributes
-and a flag telling you if the user is already modified and need
-to be saved after your handler is executed. If your handler
-modifies the user object it should return True. Otherwise it should
-return False. This way djangosaml2 will know if it should save
-the user object so you don't need to do it and no more calls to
-the save method are issued.
-
+.. _hooks: https://github.com/knaperek/djangosaml2/blob/master/djangosaml2/backends.py#L181
 
 IdP setup
 =========


### PR DESCRIPTION
I spent some time in my project trying to get the `pre_user_save` signal shown in the README working to later find that it was removed from the module 😆  It looks like the documentation snuck back in with https://github.com/knaperek/djangosaml2/commit/a382e9e81d7f4a1a440a7b0130250f5c2b54c4b9.

This change updates the README to remove references to the `pre_user_save` signal and adds an example of overriding the `save_user` hook to achieve similar functionality.