### PR TITLE
Allow for custom error handling in LogoutInitView

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -497,7 +497,7 @@ class LogoutInitView(LoginRequiredMixin, SPConfigMixin, View):
                 'Error Handled - SLO not supported by IDP: {}'.format(exp))
             auth.logout(request)
             state.sync()
-            return HttpResponseRedirect(getattr(settings, 'LOGOUT_REDIRECT_URL', '/'))
+            return self.handle_unsupported_slo_exception(request, exp)
 
         auth.logout(request)
         state.sync()
@@ -532,6 +532,15 @@ class LogoutInitView(LoginRequiredMixin, SPConfigMixin, View):
         logger.error(
             'Could not logout because there only the HTTP_REDIRECT is supported')
         return HttpResponseServerError('Logout Binding not supported')
+
+    def handle_unsupported_slo_exception(self, request, exception, *args, **kwargs):
+        """ Subclasses may override this method to implement custom logic for
+            handling logout errors. Redirects to LOGOUT_REDIRECT_URL by default.
+
+            For example, a site may want to perform additional logic and redirect
+            users somewhere other than the LOGOUT_REDIRECT_URL.
+        """
+        return HttpResponseRedirect(getattr(settings, 'LOGOUT_REDIRECT_URL', '/'))
 
 
 @method_decorator(csrf_exempt, name='dispatch')


### PR DESCRIPTION
This adds a method in `LogoutInitView` that can overridden to provide custom logic for handling `LogoutError`s in `LogoutInitView`. By default, it will redirect to `LOGOUT_REDIRECT_URL` or `/` as is currently the case.

This addresses the need where a site needs to redirect users somewhere other than `LOGOUT_REDIRECT_URL` during a `LogoutError`. Prior to class based views, djangosaml2 was not handling `LogoutError`s directly, so it was possible to specify where to redirect users by catching these errors on the application side. 