### PR TITLE
Add assertion param to backed.authenticate and backend.is_authorized

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -106,7 +106,7 @@ class Saml2Backend(ModelBackend):
                          'value is missing. Probably the user '
                          'session is expired.')
 
-    def authenticate(self, request, session_info=None, attribute_mapping=None, create_unknown_user=True, **kwargs):
+    def authenticate(self, request, session_info=None, attribute_mapping=None, create_unknown_user=True, assertion=None, **kwargs):
         if session_info is None or attribute_mapping is None:
             logger.info('Session info or attribute mapping are None')
             return None
@@ -121,7 +121,7 @@ class Saml2Backend(ModelBackend):
 
         logger.debug(f'attributes: {attributes}')
 
-        if not self.is_authorized(attributes, attribute_mapping, idp_entityid):
+        if not self.is_authorized(attributes, attribute_mapping, idp_entityid, assertion):
             logger.error('Request not authorized')
             return None
 
@@ -194,7 +194,7 @@ class Saml2Backend(ModelBackend):
         """ Hook to clean or filter attributes from the SAML response. No-op by default. """
         return attributes
 
-    def is_authorized(self, attributes: dict, attribute_mapping: dict, idp_entityid: str, **kwargs) -> bool:
+    def is_authorized(self, attributes: dict, attribute_mapping: dict, idp_entityid: str, assertion: object, **kwargs) -> bool:
         """ Hook to allow custom authorization policies based on SAML attributes. True by default. """
         return True
 

--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -106,7 +106,7 @@ class Saml2Backend(ModelBackend):
                          'value is missing. Probably the user '
                          'session is expired.')
 
-    def authenticate(self, request, session_info=None, attribute_mapping=None, create_unknown_user=True, assertion=None, **kwargs):
+    def authenticate(self, request, session_info=None, attribute_mapping=None, create_unknown_user=True, assertion_info=None, **kwargs):
         if session_info is None or attribute_mapping is None:
             logger.info('Session info or attribute mapping are None')
             return None
@@ -121,7 +121,7 @@ class Saml2Backend(ModelBackend):
 
         logger.debug(f'attributes: {attributes}')
 
-        if not self.is_authorized(attributes, attribute_mapping, idp_entityid, assertion):
+        if not self.is_authorized(attributes, attribute_mapping, idp_entityid, assertion_info):
             logger.error('Request not authorized')
             return None
 
@@ -194,7 +194,7 @@ class Saml2Backend(ModelBackend):
         """ Hook to clean or filter attributes from the SAML response. No-op by default. """
         return attributes
 
-    def is_authorized(self, attributes: dict, attribute_mapping: dict, idp_entityid: str, assertion: object, **kwargs) -> bool:
+    def is_authorized(self, attributes: dict, attribute_mapping: dict, idp_entityid: str, assertion_info: dict, **kwargs) -> bool:
         """ Hook to allow custom authorization policies based on SAML attributes. True by default. """
         return True
 

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -430,7 +430,8 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
         user = auth.authenticate(request=request,
                                  session_info=session_info,
                                  attribute_mapping=attribute_mapping,
-                                 create_unknown_user=create_unknown_user)
+                                 create_unknown_user=create_unknown_user,
+                                 assertion=response.assertion)
         if user is None:
             logger.warning(
                 "Could not authenticate user received in SAML Assertion. Session info: %s", session_info)

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -419,8 +419,12 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
 
         # authenticate the remote user
         session_info = response.session_info()
+
+        # assertion_info
         assertion = response.assertion
-        assertion_info = {'assertion_id': assertion.id, 'not_on_or_after': assertion.conditions.not_on_or_after if assertion.conditions else None}
+        subject_confirmation_data = [sc.subject_confirmation_data for sc in assertion.subject.subject_confirmation]
+        subject_nooa = [scd.not_on_or_after if scd else None for scd in subject_confirmation_data]
+        assertion_info = {'assertion_id': assertion.id, 'not_on_or_after': subject_nooa}
 
         if callable(attribute_mapping):
             attribute_mapping = attribute_mapping()

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -419,6 +419,8 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
 
         # authenticate the remote user
         session_info = response.session_info()
+        assertion = response.assertion
+        assertion_info = {'assertion_id': assertion.id, 'not_on_or_after': assertion.conditions.not_on_or_after if assertion.conditions else None}
 
         if callable(attribute_mapping):
             attribute_mapping = attribute_mapping()
@@ -431,7 +433,7 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
                                  session_info=session_info,
                                  attribute_mapping=attribute_mapping,
                                  create_unknown_user=create_unknown_user,
-                                 assertion=response.assertion)
+                                 assertion_info=assertion_info)
         if user is None:
             logger.warning(
                 "Could not authenticate user received in SAML Assertion. Session info: %s", session_info)


### PR DESCRIPTION
PR for https://github.com/peppelinux/djangosaml2/issues/250

In [SAML standard doc, section 4.1.4.5](https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf) it states ```The service provider MUST ensure that bearer assertions are not replayed, by maintaining the set of used ID values for the length of time for which the assertion would be considered valid based on the NotOnOrAfter attribute in the <SubjectConfirmationData>.```.

This is not taken care of by djangosaml2 because djangosaml2 doesn't want to worry about the storage to store the seen assertion ids, but it should provide hooks for the consumer to add the assertion id check. The existing backend.is_authorized can be used, but it does not provide the assertion information, hence adding the assertion as an additional parameter to the `is_authorized` hook