### PR TITLE
Cast major/minor django VERSION number into float before comparing

### DIFF
--- a/djangosaml2/middleware.py
+++ b/djangosaml2/middleware.py
@@ -9,7 +9,8 @@ from django.utils.cache import patch_vary_headers
 from django.utils.http import http_date
 
 
-SAMESITE_NONE = None if (VERSION[0] < 3.1) else 'None'
+django_version = float('{}.{}'.format(*VERSION[:2]))
+SAMESITE_NONE = None if django_version < 3.1 else 'None'
 
 
 class SamlSessionMiddleware(SessionMiddleware):


### PR DESCRIPTION
This PR fixing a minor bug in the saml session middleware so that the saml_session samesite cookie flag is correctly set to "None" if the django version >= 3.1