### PR TITLE
Implement IdP Scoping parameter for SPs suggesting an entityID to a proxy

### DIFF
--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -206,6 +206,20 @@ For example::
 
 see AARC Blueprint specs `here <https://zenodo.org/record/4596667/files/AARC-G061-A_specification_for_IdP_hinting.pdf>`_.
 
+
+IdP scoping
+===========
+The SP can suggest an IdP to a proxy by using the Scoping and IDPList elements in a SAML AuthnRequest. This is done using the `scoping` parameter to the login URL.
+
+``https://sp.example.org/saml2/login/?scoping=https://idp.example.org``
+
+This parameter can be combined with the IdP parameter if multiple IdPs are present in the metadata, otherwise the first is used.
+
+``https://sp.example.org/saml2/login/?scoping=https://idp.example.org&idp=https://proxy.example.com/metadata``
+
+Currently there is support for a single IDPEntry in the IDPList.
+
+
 Custom and dynamic configuration loading
 ========================================
 


### PR DESCRIPTION
Referring to https://github.com/peppelinux/djangosaml2/issues/271, this implements basic functionality to add a Scoping element with a single IDPEntry in an IDPList, in order to suggest a downstream IdP to a SAML proxy