### PR TITLE
Add default_auto_field setting, strongly recommended in Django 3.2

### DIFF
--- a/tests/testprofiles/app.py
+++ b/tests/testprofiles/app.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class TestProfilesConfig(AppConfig):
     name = 'testprofiles'
     verbose_name = 'Test profiles'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Without this Django issues the following warnings when running the tests:

```
System check identified some issues:

WARNINGS:
testprofiles.RequiredFieldUser: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
testprofiles.StandaloneUserModel: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
testprofiles.TestUser: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```

