### PR TITLE
Authn Context and general SAML2 Request improvement

### DIFF
--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -221,6 +221,17 @@ This parameter can be combined with the IdP parameter if multiple IdPs are prese
 Currently there is support for a single IDPEntry in the IDPList.
 
 
+Authn Context
+=============
+
+We can define the authentication context in settings.SAML_CONFIG['service']['sp'] as follows::
+
+    'requested_authn_context': {
+        'authn_context_class_ref': saml2.saml.AUTHN_PASSWORD_PROTECTED,
+        'comparison': "exact"
+    }
+
+
 Custom and dynamic configuration loading
 ========================================
 


### PR DESCRIPTION
* feat: sso_kwargs now handled with some custom methods ... that can be inherited :)
* feat: authn context support, with or without this https://github.com/IdentityPython/pysaml2/pull/807 (better with!)
* feat: authn context documentation

This PR closes https://github.com/IdentityPython/djangosaml2/pull/288/files

just add this in SAML_CONFIG['service']['sp']

````
            'requested_authn_context': {
                'authn_context_class_ref': saml2.saml.AUTHN_PASSWORD_PROTECTED,
                'comparison': "exact"
            }
````

