### PR TITLE
Fixed requested_authn_context config

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -162,9 +162,9 @@ class LoginView(SPConfigMixin, View):
         if ac:
             sso_kwargs["requested_authn_context"] = RequestedAuthnContext(
                     authn_context_class_ref=[
-                        AuthnContextClassRef(ac['authn_context_class_ref']),
+                        AuthnContextClassRef(ref) for ref in ac['authn_context_class_ref']
                     ],
-                    comparison = ac.get('comparison', "minimum"),
+                    comparison=ac.get('comparison', "minimum"),
                 )
 
     def load_sso_kwargs(self, sso_kwargs):

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -219,7 +219,7 @@ Authn Context
 We can define the authentication context in settings.SAML_CONFIG['service']['sp'] as follows::
 
     'requested_authn_context': {
-        'authn_context_class_ref': saml2.saml.AUTHN_PASSWORD_PROTECTED,
+        'authn_context_class_ref': [saml2.saml.AUTHN_PASSWORD_PROTECTED],
         'comparison': "exact"
     }
 


### PR DESCRIPTION
There can be multiple `AuthnContextClassRef`, the previous implementation didn't took that into consideration. 