### PR TITLE
v1.3.2

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -349,7 +349,7 @@ class LoginView(SPConfigMixin, View):
                         },
                     })
                 except TemplateDoesNotExist as e:
-                    logger.error(
+                    logger.debug(
                         f'TemplateDoesNotExist: [{self.post_binding_form_template}] - {e}'
                     )
 

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -596,17 +596,24 @@ class LogoutInitView(LoginRequiredMixin, SPConfigMixin, View):
             logger.warning(
                 'The session does not contain the subject id for user %s', request.user)
 
+        _error = None
         try:
             result = client.global_logout(subject_id)
         except LogoutError as exp:
             logger.exception(
                 'Error Handled - SLO not supported by IDP: {}'.format(exp))
-            auth.logout(request)
-            state.sync()
-            return self.handle_unsupported_slo_exception(request, exp)
+            _error = exp
+        except UnsupportedBinding as exp:
+            logger.exception(
+                'Error Handled - SLO - unsupported binding by IDP: {}'.format(exp))
+            _error = exp
 
         auth.logout(request)
         state.sync()
+
+        if _error:
+            return self.handle_unsupported_slo_exception(request, _error)
+
 
         if not result:
             logger.error(

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*rnames):
 
 setup(
     name='djangosaml2',
-    version='1.3.0',
+    version='1.3.2',
     description='pysaml2 integration for Django',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- feat: Unsupported Binding exception in SLO - a workaround to go ahead when SLO is absent in IdP
- custom sso POST template: changed from error to debug when theresn't any custom template to load (fallback to pysaml2 default)