### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -181,6 +181,9 @@ class LoginView(SPConfigMixin, View):
     def load_sso_kwargs(self, sso_kwargs):
         """ Inherit me if you want to put your desidered things in sso_kwargs """
 
+    def add_idp_hinting(self, http_response):
+        return add_idp_hinting(self.request, http_response) or http_response
+
     def get(self, request, *args, **kwargs):
         logger.debug('Login process started')
         next_path = self.get_next_path(request)
@@ -388,7 +391,7 @@ class LoginView(SPConfigMixin, View):
         )
 
         # idp hinting support, add idphint url parameter if present in this request
-        response = add_idp_hinting(request, http_response) or http_response
+        response = self.add_idp_hinting(http_response) or http_response
         return response
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*rnames):
 
 setup(
     name='djangosaml2',
-    version='1.3.3',
+    version='1.3.4',
     description='pysaml2 integration for Django',
     long_description=read('README.md'),
     long_description_content_type='text/markdown',

--- a/tests/testprofiles/tests.py
+++ b/tests/testprofiles/tests.py
@@ -219,7 +219,7 @@ class Saml2BackendTests(TestCase):
         # User creation does not fail if several fields are required.
         user, created = self.backend.get_or_create_user(self.backend._user_lookup_attribute, 'john@example.org', True, None, None, None, None)
 
-        self.assertEquals(user.email, 'john@example.org')
+        self.assertEqual(user.email, 'john@example.org')
         self.assertIs(user.email_verified, None)
 
         user = self.backend._update_user(user, attributes, attribute_mapping, created)


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268 