### PR TITLE
Added a step to fetch the selected idp when using MDQ

### DIFF
--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -22,6 +22,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import resolve_url
+from saml2.mdstore import MetaDataMDX
 
 try:
     from django.utils.http import url_has_allowed_host_and_scheme
@@ -38,13 +39,16 @@ def get_custom_setting(name: str, default=None):
     return getattr(settings, name, default)
 
 
-def available_idps(config: SPConfig, langpref=None) -> dict:
+def available_idps(config: SPConfig, langpref=None, idp_to_check=None) -> dict:
     if langpref is None:
         langpref = "en"
 
     idps = set()
 
     for metadata in config.metadata.metadata.values():
+        # initiate a fetch to the selected idp when using MDQ, otherwise the MetaDataMDX is an empty database
+        if isinstance(metadata, MetaDataMDX) and idp_to_check and len(str(idp_to_check)) > 0:
+            m = metadata[idp_to_check]
         result = metadata.any("idpsso_descriptor", "single_sign_on_service")
         if result:
             idps.update(result.keys())

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -39,7 +39,7 @@ def get_custom_setting(name: str, default=None):
     return getattr(settings, name, default)
 
 
-def available_idps(config: SPConfig, langpref=None, idp_to_check=None) -> dict:
+def available_idps(config: SPConfig, langpref=None, idp_to_check: str = None) -> dict:
     if langpref is None:
         langpref = "en"
 
@@ -47,7 +47,7 @@ def available_idps(config: SPConfig, langpref=None, idp_to_check=None) -> dict:
 
     for metadata in config.metadata.metadata.values():
         # initiate a fetch to the selected idp when using MDQ, otherwise the MetaDataMDX is an empty database
-        if isinstance(metadata, MetaDataMDX) and idp_to_check and len(str(idp_to_check)) > 0:
+        if isinstance(metadata, MetaDataMDX) and idp_to_check:
             m = metadata[idp_to_check]
         result = metadata.any("idpsso_descriptor", "single_sign_on_service")
         if result:

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -245,6 +245,10 @@ class LoginView(SPConfigMixin, View):
                     },
                 )
 
+        # when using MDQ and DS we need to initiate a check on the selected idp,
+        # otherwise the available idps will be empty
+        configured_idps = available_idps(conf, idp_to_check=selected_idp)
+
         # is the first one, otherwise next logger message will print None
         if not configured_idps:  # pragma: no cover
             raise IdPConfigurationMissing("IdP is missing or its metadata is expired.")

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.3.6",
+    version="1.4.0",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When using MDQ as the primary and only metadata source, the `available_idps` will always return an emtpy dict unless there is a lookup request is made to the MetaDataMDX object. This can be initiated by querying the MetaDataMDX object for the IDP selected through the Discovery Service. There may be a cleaner solution, this a minimal working fix or workaround as of now. (See Issue #325 )