### PR TITLE
Allows to redirect to domains listed in SAML_ALLOWED_HOSTS

### DIFF
--- a/djangosaml2/middleware.py
+++ b/djangosaml2/middleware.py
@@ -9,6 +9,8 @@ from django.utils.http import http_date
 from django.contrib.sessions.backends.base import UpdateError
 from django.contrib.sessions.middleware import SessionMiddleware
 
+from djangosaml2.utils import get_target_domain
+
 django_version = float("{}.{}".format(*VERSION[:2]))
 SAMESITE_NONE = None if django_version < 3.1 else "None"
 
@@ -70,7 +72,7 @@ class SamlSessionMiddleware(SessionMiddleware):
                         request.saml_session.session_key,
                         max_age=max_age,
                         expires=expires,
-                        domain=settings.SESSION_COOKIE_DOMAIN,
+                        domain=get_target_domain(request),
                         path=settings.SESSION_COOKIE_PATH,
                         secure=settings.SESSION_COOKIE_SECURE or None,
                         httponly=settings.SESSION_COOKIE_HTTPONLY or None,

--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -210,8 +210,8 @@ class SAML2Tests(TestCase):
 
     def test_login_evil_redirect(self):
         """
-        Make sure that if we give an URL other than our own host as the next
-        parameter, it is replaced with the fallback login redirect url.
+        Make sure that if we give an URL as the next parameter other than our own host, and one that
+        is not listed in SAML_ALLOWED_HOSTS, it is replaced with the fallback login redirect url.
         """
 
         # monkey patch SAML configuration
@@ -241,6 +241,32 @@ class SAML2Tests(TestCase):
                     params = parse_qs(url.query)
 
                     self.assertEqual(params["RelayState"], ["/dashboard/"])
+
+    def test_login_allowed_redirect(self):
+        """
+        A redirect URL using a domain that is listed in SAML_ALLOWED_HOSTS should
+        be accepted as valid.
+        """
+
+        settings.SAML_ALLOWED_HOSTS = ['allowed.com']
+        settings.SAML_CONFIG = conf.create_conf(
+            sp_host="sp.example.com",
+            idp_hosts=["idp.example.com"],
+            metadata_file="remote_metadata_one_idp.xml",
+        )
+
+        response = self.client.get(
+            reverse("saml2_login") + "?next=http://allowed.com/sample-path"
+        )
+        url = urlparse(response["Location"])
+        params = parse_qs(url.query)
+
+        self.assertEqual(params["RelayState"], ["http://allowed.com/sample-path"])
+
+        # Making sure the cookie domain is set to the target domain:
+        cookie = response.cookies["saml_session"]
+        print("cookie=", cookie)
+        self.assertEqual(cookie["domain"], "allowed.com")
 
     def test_no_redirect(self):
         """

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -118,11 +118,11 @@ view to djangosaml2 wb path, like ``/saml2/login/``.
 Handling Post-Login Redirects
 =============================
 
-It is often desireable for the client to maintain the URL state (or at least manage it) so that
+It is often desirable for the client to maintain the URL state (or at least manage it) so that
 the URL once authentication has completed is consistent with the desired application state (such
 as retaining query parameters, etc.)  By default, the HttpRequest objects get_host() method is used
 to determine the hostname of the server, and redirect URL's are allowed so long as the destination
-host matches the output of get_host().  However, in some cases it becomes desireable for additional
+host matches the output of get_host().  However, in some cases it becomes desirable for additional
 hostnames to be used for the post-login redirect.  In such cases, the setting::
 
   SAML_ALLOWED_HOSTS = []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@ pytest
 pytest-django
 pytest-cov
 codecov
+defusedxml
+pysaml2


### PR DESCRIPTION
Allows clients to specify a redirect url to a domain other than the get_host(), if it is listed in SAML_ALLOWED_HOSTS.