### PR TITLE
Django 4.1 compat

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        django-version: ["3.2", "4.0"]
+        django-version: ["3.2", "4.0", "4.1"]
         include:
         - python-version: "3.7"
           django-version: "3.2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'docs|migrations'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -32,12 +32,12 @@ repos:
         args: ['--settings-path=pyproject.toml']
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.4.0
+    rev: 1.7.0
     hooks:
       - id: django-upgrade
         args: [--target-version, "3.2"]

--- a/djangosaml2/__init__.py
+++ b/djangosaml2/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "djangosaml2.apps.DjangoSaml2Config"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.5.0",
+    version="1.5.1",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -109,6 +109,10 @@ USE_L10N = True
 USE_TZ = True
 
 
+# https://docs.djangoproject.com/en/dev/ref/settings/#default-auto-field
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{3.7,3.8,3.9,3.10}-django{3.2,4.0}
+    py{3.7,3.8,3.9,3.10}-django{3.2,4.0,4.1}
 
 [testenv]
 commands =
@@ -10,6 +10,7 @@ commands =
 deps =
     django3.2: django~=3.2
     django4.0: django~=4.0
+    django4.1: django==4.1b1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     .
 


### PR DESCRIPTION
The main issue was with django's LogoutView, which has changed a bit in 4.1. `GET` for logout is also deprecated and will be removed in [5.0](https://docs.djangoproject.com/en/dev/releases/4.1/#log-out-via-get).

I thus opted to handle manually logging out. Let me know what you think.

I also removed `next_page` handling which was never hit (and misconfigured since `next_page` should be an `as_view` arg).

Finally, `default_app_config` was [removed](https://docs.djangoproject.com/en/dev/releases/4.1/#features-removed-in-4-1).