### PR TITLE
Remove occurrences of my old nonexistent email address

### DIFF
--- a/djangosaml2/tests/remote_metadata.xml
+++ b/djangosaml2/tests/remote_metadata.xml
@@ -27,7 +27,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
   <md:EntityDescriptor entityID="https://idp1.example.com/simplesaml/saml2/idp/metadata.php">
@@ -57,7 +57,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
   <md:EntityDescriptor entityID="https://idp2.example.com/simplesaml/saml2/idp/metadata.php">
@@ -87,7 +87,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
   <md:EntityDescriptor entityID="https://idp3.example.com/simplesaml/saml2/idp/metadata.php">
@@ -117,7 +117,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
 </md:EntitiesDescriptor>

--- a/djangosaml2/tests/remote_metadata_one_idp.xml
+++ b/djangosaml2/tests/remote_metadata_one_idp.xml
@@ -27,7 +27,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
 </md:EntitiesDescriptor>

--- a/djangosaml2/tests/remote_metadata_post_binding.xml
+++ b/djangosaml2/tests/remote_metadata_post_binding.xml
@@ -27,7 +27,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
 </md:EntitiesDescriptor>

--- a/djangosaml2/tests/remote_metadata_three_idps.xml
+++ b/djangosaml2/tests/remote_metadata_three_idps.xml
@@ -27,7 +27,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
   <md:EntityDescriptor entityID="https://idp2.example.com/simplesaml/saml2/idp/metadata.php">
@@ -57,7 +57,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
   <md:EntityDescriptor entityID="https://idp3.example.com/simplesaml/saml2/idp/metadata.php">
@@ -87,7 +87,7 @@
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
 </md:EntitiesDescriptor>

--- a/djangosaml2/tests/sp_metadata.xml
+++ b/djangosaml2/tests/sp_metadata.xml
@@ -36,7 +36,7 @@ JMCJ3g73lNb3DTDS0UO+zLTlTHb1M/uJJnGY/CCb4kmoPRpxgMbybOh2TVfx9RHm
     </md:Organization>
     <md:ContactPerson contactType="technical">
       <md:SurName>Administrator</md:SurName>
-      <md:EmailAddress>lgs@yaco.es</md:EmailAddress>
+      <md:EmailAddress>lorenzo.gil.sanchez@gmail.com</md:EmailAddress>
     </md:ContactPerson>
   </md:EntityDescriptor>
 </md:EntitiesDescriptor>

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -581,7 +581,7 @@ settings.py file under the SAML_CONFIG option. We will see a typical configurati
         {'given_name': 'Lorenzo',
          'sur_name': 'Gil',
          'company': 'Yaco Sistemas',
-         'email_address': 'lorenzo.gil.sanchez@gmai.com',
+         'email_address': 'lorenzo.gil.sanchez@gmail.com',
          'contact_type': 'technical'},
         {'given_name': 'Angel',
          'sur_name': 'Fernandez',

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -581,7 +581,7 @@ settings.py file under the SAML_CONFIG option. We will see a typical configurati
         {'given_name': 'Lorenzo',
          'sur_name': 'Gil',
          'company': 'Yaco Sistemas',
-         'email_address': 'lgs@yaco.es',
+         'email_address': 'lorenzo.gil.sanchez@gmai.com',
          'contact_type': 'technical'},
         {'given_name': 'Angel',
          'sur_name': 'Fernandez',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2012 Yaco Sistemas <lgs@yaco.es>
+# Copyright (C) 2011-2012 Yaco Sistemas <lorenzo.gil.sanchez@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ setup(
     ],
     keywords="django,pysaml2,sso,saml2,federated authentication,authentication",
     author="Yaco Sistemas and independent contributors",
-    author_email="lgs@yaco.es",
+    author_email="lorenzo.gil.sanchez@gmail.com",
     maintainer="Giuseppe De Marco",
     url="https://github.com/IdentityPython/djangosaml2",
     download_url="https://pypi.org/project/djangosaml2/",


### PR DESCRIPTION
In case people read the source code and copyright header and want to reach me, now they can use my personal email address.

The company Yaco, which funded the initial work for this project, does not exist anymore and therefore the address `lgs@yaco.es` does not exist.