### PR TITLE
Pass the current http.request to the _update_user backend hook

### DIFF
--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -166,7 +166,7 @@ class Saml2Backend(ModelBackend):
         # Update user with new attributes from incoming request
         if user is not None:
             user = self._update_user(
-                user, attributes, attribute_mapping, force_save=created
+                user, attributes, attribute_mapping, force_save=created, request=request
             )
 
         if self.user_can_authenticate(user):

--- a/djangosaml2/backends.py
+++ b/djangosaml2/backends.py
@@ -20,9 +20,9 @@ from typing import Any, Optional, Tuple
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, MultipleObjectsReturned
-
 from django.contrib import auth
 from django.contrib.auth.backends import ModelBackend
+from django.http.request import HttpRequest
 
 logger = logging.getLogger("djangosaml2")
 
@@ -173,7 +173,7 @@ class Saml2Backend(ModelBackend):
             return user
 
     def _update_user(
-        self, user, attributes: dict, attribute_mapping: dict, force_save: bool = False
+        self, user, attributes: dict, attribute_mapping: dict, force_save: bool = False, request: HttpRequest = None
     ):
         """Update a user with a set of attributes and returns the updated user.
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.5.3",
+    version="1.5.4",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
feat: Passes the current request to the _update_user hook.
This should allow developers, especially those dealing with multi-tenant sites, to make updates to the user based on the request context.
Closes https://github.com/IdentityPython/djangosaml2/issues/350