### PR TITLE
Fix XSS in the idp url parameter

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -308,8 +308,8 @@ class SAML2Tests(TestCase):
             metadata_file="remote_metadata_three_idps.xml",
         )
 
-        response = self.client.get(reverse("saml2_login") + "?idp=https://unknown.org")
-        self.assertEqual(response.status_code, 403)
+        response = self.client.get(reverse("saml2_login") + "?idp=<b>https://unknown.org</b>")
+        self.assertContains(response, "&lt;b&gt;https://unknown.org&lt;/b&gt;", status_code=403)
 
     def test_login_authn_context(self):
         sp_kwargs = {

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -30,6 +30,7 @@ from django.shortcuts import render, resolve_url
 from django.template import TemplateDoesNotExist
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.html import escape
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -152,7 +153,7 @@ class LoginView(SPConfigMixin, View):
         return next_path
 
     def unknown_idp(self, request, idp):
-        msg = f"Error: IdP EntityID {idp} was not found in metadata"
+        msg = f"Error: IdP EntityID {escape(idp)} was not found in metadata"
         logger.error(msg)
         return HttpResponse(msg.format("Please contact technical support."), status=403)
 


### PR DESCRIPTION
This PR fixes an XSS issue in the login view where arbitrary input from the `idp` parameter can end up in the resulting html unescaped.