### PR TITLE
Split authenticate into separate overridable function

### DIFF
--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -550,7 +550,40 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
         if callable(create_unknown_user):
             create_unknown_user = create_unknown_user()
 
+        try:
+            user = self.authenticate_user(
+                request,
+                session_info,
+                attribute_mapping,
+                create_unknown_user,
+                assertion_info
+            )
+        except PermissionDenied as e:
+            return self.handle_acs_failure(
+                request,
+                exception=e,
+                session_info=session_info,
+            )
+
+        relay_state = self.build_relay_state()
+        custom_redirect_url = self.custom_redirect(user, relay_state, session_info)
+        if custom_redirect_url:
+            return HttpResponseRedirect(custom_redirect_url)
+        relay_state = validate_referral_url(request, relay_state)
+        logger.debug("Redirecting to the RelayState: %s", relay_state)
+        return HttpResponseRedirect(relay_state)
+
+    def authenticate_user(
+            self,
+            request,
+            session_info,
+            attribute_mapping,
+            create_unknown_user,
+            assertion_info
+        ):
+        """Calls Django's authenticate method after the SAML response is verified"""
         logger.debug("Trying to authenticate the user. Session info: %s", session_info)
+
         user = auth.authenticate(
             request=request,
             session_info=session_info,
@@ -563,11 +596,7 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
                 "Could not authenticate user received in SAML Assertion. Session info: %s",
                 session_info,
             )
-            return self.handle_acs_failure(
-                request,
-                exception=PermissionDenied("No user could be authenticated."),
-                session_info=session_info,
-            )
+            raise PermissionDenied("No user could be authenticated.")
 
         auth.login(self.request, user)
         _set_subject_id(request.saml_session, session_info["name_id"])
@@ -575,14 +604,6 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
 
         self.post_login_hook(request, user, session_info)
         self.customize_session(user, session_info)
-
-        relay_state = self.build_relay_state()
-        custom_redirect_url = self.custom_redirect(user, relay_state, session_info)
-        if custom_redirect_url:
-            return HttpResponseRedirect(custom_redirect_url)
-        relay_state = validate_referral_url(request, relay_state)
-        logger.debug("Redirecting to the RelayState: %s", relay_state)
-        return HttpResponseRedirect(relay_state)
 
     def post_login_hook(
         self, request: HttpRequest, user: settings.AUTH_USER_MODEL, session_info: dict

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -605,6 +605,8 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
         self.post_login_hook(request, user, session_info)
         self.customize_session(user, session_info)
 
+        return user
+
     def post_login_hook(
         self, request: HttpRequest, user: settings.AUTH_USER_MODEL, session_info: dict
     ) -> None:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.5.6",
+    version="1.5.7",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR splits the user authentication in the AssertionConsumerServiceView into a separate function that can be overridden separately. No functionality has been changed.

We've been using this library for a long time and have multiple IdPs that we connect to. Unfortunately that means we sometimes get duplicate user records created, where the same individual has accounts with more than one IdP. We're changing our flow to incorporate merging records together, but as part of that we need users to authenticate with their IdP for the second record / email address we will merge with. We want this to complete without them automatically then logging in to that account. 

The cleanest way we can see to do this would be to override just the user authentication part of the post method of the AssertionConsumerServiceView meaning that we are confident that the user controls the account but we keep the user from their first auth available. This change means that we don't have to work around it with overrides to the backend and the handle_acs_failure methods, which would be possible but inelegant.

This small change would allow our flow to work tidily and be easy to understand. We appreciate any feedback you may have.

/cc @jafacakes2011 @lgarvey 