### PR TITLE
Separate out the condition for skipping login

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.5.7",
+    version="1.5.8",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The `LoginView` class has a get method that begins with some logic to determine if the login form should be presented to the current user. If someone wants to override this logic, they have to override the whole `get` method.

This PR separates the conditions into an overridable method so the `get` method can focus on building the login form/page.