### PR TITLE
Allow overriding SameSite value for session cookie

### DIFF
--- a/djangosaml2/middleware.py
+++ b/djangosaml2/middleware.py
@@ -26,6 +26,8 @@ class SamlSessionMiddleware(SessionMiddleware):
         session every time, save the changes and set a session cookie or delete
         the session cookie if the session has been emptied.
         """
+        SAMESITE = getattr(settings, "SAML_SESSION_COOKIE_SAMESITE", SAMESITE_NONE)
+
         try:
             accessed = request.saml_session.accessed
             modified = request.saml_session.modified
@@ -39,7 +41,7 @@ class SamlSessionMiddleware(SessionMiddleware):
                 self.cookie_name,
                 path=settings.SESSION_COOKIE_PATH,
                 domain=settings.SESSION_COOKIE_DOMAIN,
-                samesite=SAMESITE_NONE,
+                samesite=SAMESITE,
             )
             patch_vary_headers(response, ("Cookie",))
         else:
@@ -74,6 +76,6 @@ class SamlSessionMiddleware(SessionMiddleware):
                         path=settings.SESSION_COOKIE_PATH,
                         secure=settings.SESSION_COOKIE_SECURE or None,
                         httponly=settings.SESSION_COOKIE_HTTPONLY or None,
-                        samesite=SAMESITE_NONE,
+                        samesite=SAMESITE,
                     )
         return response

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -62,6 +62,10 @@ You can even configure the SAML cookie name as follows::
 
   SAML_SESSION_COOKIE_NAME = 'saml_session'
 
+By default, djangosaml2 will set "SameSite=None" for the SAML session cookie. This value can be configured as follows::
+
+  SAML_SESSION_COOKIE_SAMESITE = 'Lax'
+
 Remember that in your browser "SameSite=None" attribute MUST also
 have the "Secure" attribute, which is required in order to use "SameSite=None", otherwise the cookie will be blocked, so you must also set::
 
@@ -69,7 +73,7 @@ have the "Secure" attribute, which is required in order to use "SameSite=None", 
 
 .. Note::
 
-  djangosaml2 will attempt to set the ``SameSite`` attribute of the SAML session cookie to ``None`` so that it can be
+  djangosaml2 will by default attempt to set the ``SameSite`` attribute of the SAML session cookie to ``None`` so that it can be
   used in cross-site requests, but this is only possible with Django 3.1 or higher. If you are experiencing issues with
   unsolicited requests or cookies not being sent (particularly when using the HTTP-POST binding), consider upgrading
   to Django 3.1 or higher. If you can't do that, configure "allow_unsolicited" to True in pySAML2 configuration.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.5.8",
+    version="1.6.0",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When testing against a dev instance without TLS enabled, because browsers are requiring SameSite=None to be paired with Secure=True, the session cookie will not be set and causes SSO issues.

This change allows the SameSite value to be customized via a settngs value.