### PR TITLE
Logout relaystate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.6.0",
+    version="1.7.0",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The logout endpoint should support both `next` and `RelayState` parameters for post-login redirection, same as the login endpoint.

Fixes #379 