### PR TITLE
Add additional RelayState URL validation

### DIFF
--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -22,6 +22,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import resolve_url
+from django.urls import NoReverseMatch
 from django.utils.http import url_has_allowed_host_and_scheme
 
 from saml2.config import SPConfig
@@ -99,6 +100,24 @@ def get_fallback_login_redirect_url():
 
 
 def validate_referral_url(request, url):
+    # Ensure the url is even a valid URL; sometimes the given url is a
+    # RelayState containing PySAML data.
+    # Some technically-valid urls will be fail this check, so the
+    # SAML_STRICT_URL_VALIDATION setting can be used to turn off this check.
+    # This should only happen if there is no slash, host and/or protocol in the
+    # given URL. A better fix would be to add those to the RelayState.
+    saml_strict_url_validation = getattr(
+        settings,
+        "SAML_STRICT_URL_VALIDATION",
+        True
+    )
+    try:
+        if saml_strict_url_validation:
+            url = resolve_url(url)
+    except NoReverseMatch:
+        logger.debug("Could not validate given referral url is a valid URL")
+        return None
+
     # Ensure the user-originating redirection url is safe.
     # By setting SAML_ALLOWED_HOSTS in settings.py the user may provide a list of "allowed"
     # hostnames for post-login redirects, much like one would specify ALLOWED_HOSTS .
@@ -109,7 +128,10 @@ def validate_referral_url(request, url):
     )
 
     if not url_has_allowed_host_and_scheme(url=url, allowed_hosts=saml_allowed_hosts):
-        return get_fallback_login_redirect_url()
+        logger.debug("Referral URL not in SAML_ALLOWED_HOSTS or of the origin "
+                     "host.")
+        return None
+
     return url
 
 

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -113,6 +113,7 @@ def validate_referral_url(request, url):
     )
     try:
         if saml_strict_url_validation:
+            # This will also resolve Django URL pattern names
             url = resolve_url(url)
     except NoReverseMatch:
         logger.debug("Could not validate given referral url is a valid URL")

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -575,7 +575,7 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
             return HttpResponseRedirect(custom_redirect_url)
 
         relay_state = validate_referral_url(request, relay_state)
-        if relay_state is None:
+        if not relay_state:
             logger.debug(
                 "RelayState is not a valid URL, redirecting to fallback: %s",
                 relay_state

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -99,6 +99,7 @@ def _get_next_path(request: HttpRequest) -> Optional[str]:
         return None
 
     next_path = validate_referral_url(request, next_path)
+
     return next_path
 
 
@@ -572,7 +573,15 @@ class AssertionConsumerServiceView(SPConfigMixin, View):
         custom_redirect_url = self.custom_redirect(user, relay_state, session_info)
         if custom_redirect_url:
             return HttpResponseRedirect(custom_redirect_url)
+
         relay_state = validate_referral_url(request, relay_state)
+        if relay_state is None:
+            logger.debug(
+                "RelayState is not a valid URL, redirecting to fallback: %s",
+                relay_state
+            )
+            return HttpResponseRedirect(get_fallback_login_redirect_url())
+
         logger.debug("Redirecting to the RelayState: %s", relay_state)
         return HttpResponseRedirect(relay_state)
 
@@ -825,12 +834,17 @@ def finish_logout(request, response):
 
         next_path = _get_next_path(request)
         if next_path is not None:
+            logger.debug("Redirecting to the RelayState: %s", next_path)
             return HttpResponseRedirect(next_path)
         elif settings.LOGOUT_REDIRECT_URL is not None:
             fallback_url = resolve_url(settings.LOGOUT_REDIRECT_URL)
+            logger.debug("No valid RelayState found; Redirecting to "
+                         "LOGOUT_REDIRECT_URL")
             return HttpResponseRedirect(fallback_url)
         else:
             current_site = get_current_site(request)
+            logger.debug("No valid RelayState or LOGOUT_REDIRECT_URL found, "
+                         "rendering fallback template.")
             return render(
                 request,
                 "registration/logged_out.html",

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -122,11 +122,11 @@ view to djangosaml2 wb path, like ``/saml2/login/``.
 Handling Post-Login Redirects
 =============================
 
-It is often desireable for the client to maintain the URL state (or at least manage it) so that
+It is often desirable for the client to maintain the URL state (or at least manage it) so that
 the URL once authentication has completed is consistent with the desired application state (such
 as retaining query parameters, etc.)  By default, the HttpRequest objects get_host() method is used
 to determine the hostname of the server, and redirect URL's are allowed so long as the destination
-host matches the output of get_host().  However, in some cases it becomes desireable for additional
+host matches the output of get_host().  However, in some cases it becomes desirable for additional
 hostnames to be used for the post-login redirect.  In such cases, the setting::
 
   SAML_ALLOWED_HOSTS = []
@@ -137,6 +137,20 @@ may be specified by the client - typically with the ?next= parameter.)
 In the absence of a ``?next=parameter``, the ``ACS_DEFAULT_REDIRECT_URL`` or ``LOGIN_REDIRECT_URL`` setting will
 be used (assuming the destination hostname either matches the output of get_host() or is included in the
 ``SAML_ALLOWED_HOSTS`` setting)
+
+Redirect URL validation
+=======================
+
+Djangosaml2 will validate the redirect URL before redirecting to its value. In
+some edge-cases, valid redirect targets will fail to pass this check. This is
+limited to URLs that are a single 'word' without slashes. (For example, 'home'
+but also 'page-with-dashes').
+
+In this situation, the best solution would be to add a slash to the URL. For
+example: 'home' could be '/home' or 'home/'.
+If this is unfeasible, this strict validation can be turned off by setting
+``SAML_STRICT_URL_VALIDATION`` to ``False`` in settings.py.
+
 
 Preferred sso binding
 =====================

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -151,6 +151,8 @@ example: 'home' could be '/home' or 'home/'.
 If this is unfeasible, this strict validation can be turned off by setting
 ``SAML_STRICT_URL_VALIDATION`` to ``False`` in settings.py.
 
+During validation, `Django named URL patterns<https://docs.djangoproject.com/en/dev/topics/http/urls/#naming-url-patterns>`_
+will also be resolved. Turning off strict validation will prevent this from happening.
 
 Preferred sso binding
 =====================

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.7.0",
+    version="1.8.0",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
A PR to fix #385;

I went for a different approach than I suggested in my issue. I noticed there was a `validate_referral_url` function, which seemed like a more logical place to check for URL validity. 

In addition, when looking at that function I noticed that there was an additional (hypothetical) issue, in which a RelayState for logout would redirect to the fallback _login_ url if the RelayState didn't pass the allowed-host check. 

Thus, I decided to refactor that function to only do validation checks, and moved the logic for deciding what to do when it fails to the functions that use it.

Validating if URLs are valid is always tricky, and my choice to use Django's `resolve_url` is thus not perfect as well. It will fail on values that _could_ be a valid redirect target (I used a plain 'home' as an example). I cannot figure out a solution that will handle that gracefully but also fix the issue I described in #385. 

One could say those URLs are poorly-formatted, especially as Django by default enforces URLs have trailing slashes (which will be seen as valid). However, I don't want this stricter validation to enforce some idealistic idea of URL formatting. Thus, I decided to add a settings opt-out to my new check, as described in the additional docs I provided. 

I also added some extra debug logging, these are similar to the ones I added when debugging where my error was coming from. Hopefully they help other devs figuring out why their app does not do what they think it should ;)

Please feel free to completely disagree with this approach, I'd be happy to make a different PR if requested :) Any other comments are also welcome of course. 

-- 

As an aside, the docs say I should target the dev branch for PR's. However, that branch seems outdated, and misses the very commit that caused the issue. So I hope me targeting the master branch instead is fine?