### PR TITLE
Add CSP handler setting

### DIFF
--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -16,7 +16,7 @@ import logging
 import re
 import urllib
 import zlib
-from functools import cache, wraps
+from functools import lru_cache, wraps
 from typing import Optional
 
 from django.conf import settings
@@ -210,7 +210,7 @@ def add_idp_hinting(request, http_response) -> bool:
     return False
 
 
-@cache
+@lru_cache()
 def get_csp_handler():
     """Returns a view decorator for CSP."""
 

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -212,6 +212,8 @@ def add_idp_hinting(request, http_response) -> bool:
 
 @cache
 def get_csp_handler():
+    """Returns a view decorator for CSP."""
+
     def empty_view_decorator(view):
         return view
 
@@ -219,25 +221,9 @@ def get_csp_handler():
 
     if csp_handler_string is None:
         # No CSP handler configured, attempt to use django-csp
-        try:
-            from csp.decorators import csp_update
-        except ModuleNotFoundError:
-            # If csp is not installed, do not update fields as Content-Security-Policy
-            # is not used
-            logger.warning(
-                "django-csp could not be found, not updating Content-Security-Policy. Please "
-                "make sure CSP is configured. This can be done by your reverse proxy, "
-                "django-csp or a custom CSP handler via SAML_CSP_HANDLER. See "
-                "https://djangosaml2.readthedocs.io/contents/security.html#content-security-policy"
-                " for more information. "
-                "This warning can be disabled by setting `SAML_CSP_HANDLER=''` in your settings."
-            )
-            return empty_view_decorator
-        else:
-            # script-src 'unsafe-inline' to autosubmit forms,
-            # form-action https: to send data to IdPs
-            return csp_update(SCRIPT_SRC=["'unsafe-inline'"], FORM_ACTION=["https:"])
-    elif csp_handler_string.strip() != "":
+        return _django_csp_update_decorator() or empty_view_decorator
+
+    if csp_handler_string.strip() != "":
         # Non empty string is configured, attempt to import it
         csp_handler = import_string(csp_handler_string)
 
@@ -249,6 +235,28 @@ def get_csp_handler():
             return wrapper
 
         return custom_csp_updater
+
+    # Fall back to empty decorator when csp_handler_string is empty
+    return empty_view_decorator
+
+
+def _django_csp_update_decorator():
+    """Returns a view CSP decorator if django-csp is available, otherwise None."""
+    try:
+        from csp.decorators import csp_update
+    except ModuleNotFoundError:
+        # If csp is not installed, do not update fields as Content-Security-Policy
+        # is not used
+        logger.warning(
+            "django-csp could not be found, not updating Content-Security-Policy. Please "
+            "make sure CSP is configured. This can be done by your reverse proxy, "
+            "django-csp or a custom CSP handler via SAML_CSP_HANDLER. See "
+            "https://djangosaml2.readthedocs.io/contents/security.html#content-security-policy"
+            " for more information. "
+            "This warning can be disabled by setting `SAML_CSP_HANDLER=''` in your settings."
+        )
+        return
     else:
-        # Fall back to empty decorator when csp_handler_string is empty
-        return empty_view_decorator
+        # script-src 'unsafe-inline' to autosubmit forms,
+        # form-action https: to send data to IdPs
+        return csp_update(SCRIPT_SRC=["'unsafe-inline'"], FORM_ACTION=["https:"])

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -16,6 +16,7 @@ import logging
 import re
 import urllib
 import zlib
+from functools import cache, wraps
 from typing import Optional
 
 from django.conf import settings
@@ -24,6 +25,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.urls import NoReverseMatch
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.module_loading import import_string
 
 from saml2.config import SPConfig
 from saml2.mdstore import MetaDataMDX
@@ -206,3 +208,47 @@ def add_idp_hinting(request, http_response) -> bool:
             f"Idp hinting: cannot detect request type [{http_response.status_code}]"
         )
     return False
+
+
+@cache
+def get_csp_handler():
+    def empty_view_decorator(view):
+        return view
+
+    csp_handler_string = get_custom_setting("SAML_CSP_HANDLER", None)
+
+    if csp_handler_string is None:
+        # No CSP handler configured, attempt to use django-csp
+        try:
+            from csp.decorators import csp_update
+        except ModuleNotFoundError:
+            # If csp is not installed, do not update fields as Content-Security-Policy
+            # is not used
+            logger.warning(
+                "django-csp could not be found, not updating Content-Security-Policy. Please "
+                "make sure CSP is configured. This can be done by your reverse proxy, "
+                "django-csp or a custom CSP handler via SAML_CSP_HANDLER. See "
+                "https://djangosaml2.readthedocs.io/contents/security.html#content-security-policy"
+                " for more information. "
+                "This warning can be disabled by setting `SAML_CSP_HANDLER=''` in your settings."
+            )
+            return empty_view_decorator
+        else:
+            # script-src 'unsafe-inline' to autosubmit forms,
+            # form-action https: to send data to IdPs
+            return csp_update(SCRIPT_SRC=["'unsafe-inline'"], FORM_ACTION=["https:"])
+    elif csp_handler_string.strip() != "":
+        # Non empty string is configured, attempt to import it
+        csp_handler = import_string(csp_handler_string)
+
+        def custom_csp_updater(f):
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                return csp_handler(f(*args, **kwargs))
+
+            return wrapper
+
+        return custom_csp_updater
+    else:
+        # Fall back to empty decorator when csp_handler_string is empty
+        return empty_view_decorator

--- a/docs/source/contents/security.md
+++ b/docs/source/contents/security.md
@@ -33,3 +33,8 @@ and [configuration](https://django-csp.readthedocs.io/en/latest/configuration.ht
 guides: djangosaml2 will automatically blend in and update the headers for
 POST-bindings, so you must not include exceptions for djangosaml2 in your
 global configuration.
+
+You can specify a custom CSP handler via the `SAML_CSP_HANDLER` setting and the
+warning can be disabled by setting `SAML_CSP_HANDLER=''`. See the 
+[djangosaml2](https://djangosaml2.readthedocs.io/) documentation for more 
+information.

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -151,7 +151,7 @@ example: 'home' could be '/home' or 'home/'.
 If this is unfeasible, this strict validation can be turned off by setting
 ``SAML_STRICT_URL_VALIDATION`` to ``False`` in settings.py.
 
-During validation, `Django named URL patterns<https://docs.djangoproject.com/en/dev/topics/http/urls/#naming-url-patterns>`_
+During validation, `Django named URL patterns <https://docs.djangoproject.com/en/dev/topics/http/urls/#naming-url-patterns>`_
 will also be resolved. Turning off strict validation will prevent this from happening.
 
 Preferred sso binding

--- a/docs/source/contents/setup.rst
+++ b/docs/source/contents/setup.rst
@@ -288,6 +288,28 @@ djangosaml2 provides a hook 'is_authorized' for the SP to store assertion IDs an
         cache_storage.set(assertion_id, 'True', ex=time_delta)
         return True
 
+CSP Configuration
+=================
+By default djangosaml2 will use `django-csp <https://django-csp.readthedocs.io>`_ 
+to configure CSP if available otherwise a warning will be logged.
+
+The warning can be disabled by setting::
+
+  SAML_CSP_HANDLER = ''
+
+A custom handler can similary be specified::
+
+  # Django settings
+  SAML_CSP_HANDLER = 'myapp.utils.csp_handler'
+
+  # myapp/utils.py
+  def csp_handler(response):
+      response.headers['Content-Security-Policy'] = ...
+      return response
+
+A value of `None` is the default and will use `django-csp <https://django-csp.readthedocs.io>`_ if available.
+
+
 Users, attributes and account linking
 -------------------------------------
 

--- a/tests/testprofiles/utils.py
+++ b/tests/testprofiles/utils.py
@@ -1,0 +1,3 @@
+def csp_handler(response):
+    response.headers["Content-Security-Policy"] = "testing CSP value"
+    return response


### PR DESCRIPTION
Fixes #397

This PR adds the `SAML_CSP_HANDLER` setting so that users can specify how CSP should be updated, if at all.
The default behaviour of using `django-csp` remains the same.