### PR TITLE
Fix Content-Security-Policy if hash is included in script-src

### DIFF
--- a/djangosaml2/templates/djangosaml2/post_binding_form.html
+++ b/djangosaml2/templates/djangosaml2/post_binding_form.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" nonce="{{ request.csp_nonce }}">
+<script type="text/javascript"{% if request.csp_nonce %} nonce="{{ request.csp_nonce }}"{% endif %}>
 	window.onload = function() {
 		document.SSO_Login.submit();
 	};

--- a/djangosaml2/templates/djangosaml2/post_binding_form.html
+++ b/djangosaml2/templates/djangosaml2/post_binding_form.html
@@ -1,0 +1,15 @@
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
+	window.onload = function() {
+		document.SSO_Login.submit();
+	};
+</script>
+<p>
+You're being redirected to a SSO login page.
+Please click the button below if you're not redirected automatically within a few seconds.
+</p>
+<form method="post" action="{{ target_url }}" name="SSO_Login">
+	{% for key, value in params.items %}
+	    <input type="hidden" name="{{ key }}" value="{{ value }}" />
+	{% endfor %}
+    <input type="submit" value="Log in" />
+</form>

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -257,6 +257,6 @@ def _django_csp_update_decorator():
         )
         return
     else:
-        # script-src 'unsafe-inline' to autosubmit forms,
+        # autosubmit of forms uses nonce per default
         # form-action https: to send data to IdPs
-        return csp_update(SCRIPT_SRC=["'unsafe-inline'"], FORM_ACTION=["https:"])
+        return csp_update(FORM_ACTION=["https:"])

--- a/docs/source/contents/security.md
+++ b/docs/source/contents/security.md
@@ -34,6 +34,11 @@ guides: djangosaml2 will automatically blend in and update the headers for
 POST-bindings, so you must not include exceptions for djangosaml2 in your
 global configuration.
 
+Note that to enable autosubmit of post-bindings inline-javascript is used. To
+allow execution of this autosubmit-code a nonce is included, which works in
+default configuration but may not work if you modify `CSP_INCLUDE_NONCE_IN`
+to exclude `script-src`.
+
 You can specify a custom CSP handler via the `SAML_CSP_HANDLER` setting and the
 warning can be disabled by setting `SAML_CSP_HANDLER=''`. See the 
 [djangosaml2](https://djangosaml2.readthedocs.io/) documentation for more 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(*rnames):
 
 setup(
     name="djangosaml2",
-    version="1.9.2",
+    version="1.9.3",
     description="pysaml2 integration for Django",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
See #403 for the problem. This PR addresses option 2, so a default post-binding-template is specified which includes a nonce. We also bump the version on request of @peppelinux 