### PR TITLE
`python_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=["defusedxml>=0.4.1", "Django>=4.2", "pysaml2>=6.5.1"],
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
Added a lower bound to python though `python_requires`, aligning with the classifiers.

https://setuptools.pypa.io/en/latest/references/keywords.html

<img width="831" alt="Capture d’écran 2025-03-18 à 17 28 00" src="https://github.com/user-attachments/assets/82a6bf91-5826-4c4d-88d9-0f8ee06529ab" />
