### PR TITLE
Pypi new version gh action fix pinned version

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Setup Python 3.10.16
+      - name: Setup Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.16
+          python-version: 3.10
       - name: Install pypa/build
         run: >-
           python -m


### PR DESCRIPTION
Fixes #420 :

[Publish Python distribution to PyPI](https://github.com/IdentityPython/djangosaml2/actions/runs/15115863642/job/42486249949#step:4:6)
Version 3.10.16 with arch x64 not found Available versions: 3.10.17 (x64) 3.11.12 (x64) 3.12.10 (x64) 3.13.3 (x64) 3.9.22 (x64)